### PR TITLE
Fixed CPU ID on 64bit Linux.

### DIFF
--- a/Sources/Core/CpuID.cpp
+++ b/Sources/Core/CpuID.cpp
@@ -2,9 +2,11 @@
 
 #include "CpuID.h"
 
+#include <string.h>
+
 namespace spades {
 	
-#if defined(__i386__) || defined(_M_IX86)
+#if defined(__i386__) || defined(_M_IX86) || defined(__amd64__)
 	
 	static std::array<uint32_t, 4> cpuid(uint32_t a) {
 		std::array<uint32_t, 4> regs;

--- a/Sources/Core/CpuID.h
+++ b/Sources/Core/CpuID.h
@@ -28,7 +28,7 @@ namespace spades {
 		SimultaneousMT
 	};
 	
-#if defined(__i386__) || defined(_M_IX86)
+#if defined(__i386__) || defined(_M_IX86) || defined(__amd64__)
 	
 	class CpuID {
 		std::string vendor;


### PR DESCRIPTION
This is an fix for the issue  yvt/openspades#132.
