### PR TITLE
Realy fixed spectator mouse now

### DIFF
--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -878,9 +878,9 @@ namespace spades {
 				}
 				*/
 				
-				x = -x; y = -y;
+				x = -x;
 				if (!cg_invertMouseY)
-					y = y;
+					y = -y;
 				
 				followYaw -= x * 0.003f;
 				followPitch -= y * 0.003f;


### PR DESCRIPTION
I revived e481553 commit back, add invert support (`if (!cg_invertMouseY) y = y;`) and applied this to all spectator mode. 
Commented condition is unnecessary now. 

Now both spectator modes behaves exactly like in Ace of Spades.
