### PR TITLE
Movement slowdown when looking up and down changed to match beta better

### DIFF
--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -1170,9 +1170,16 @@ namespace spades {
 			   (input.moveRight || input.moveLeft))
 				f /= sqrtf(2.f);
 			
-			Vector3 front = GetFront();
+			// looking up or down should alter speed
+			const float maxVertLookSlowdown = 0.9f;
+			const float vertLookSlowdownStart = 0.65f; // about 40 degrees
+			float slowdownByVertLook =
+				std::max(std::abs(GetFront().z) - vertLookSlowdownStart, 0.0f) /
+				(1.0f - vertLookSlowdownStart) * maxVertLookSlowdown;
+
+			Vector3 front = GetFront2D() * (1.0f - slowdownByVertLook);
 			Vector3 left = GetLeft();
-			
+
 			if(input.moveForward){
 				velocity.x += front.x * f;
 				velocity.y += front.y * f;


### PR DESCRIPTION
Got annoyed how velocity dropped right away when looked away from horizon. Parameters for the slowdown aren't exactly same as in beta but at least walking isn't so frustrating anymore.

(This is my first github thingy ever so critique is welcome)
