### PR TITLE
Improve the minimap system ,user configurable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ CREDITS
 "JoJoe_Stinky" - Win32 Icon
 "theunknownxy" - Fixes for the Linux support
 "noway421" - Russian locale, various testing, ideas.
+"pandaro" - Improvements to the Minimap 

--- a/Resources/PakLocation.txt
+++ b/Resources/PakLocation.txt
@@ -3,7 +3,7 @@
 All paks for development vesion
 -------------------------------
 
-http://yvt.jp/files/programs/osppaks/DevPaks27.zip
+https://www.dropbox.com/s/aprb9aufqk2abe1/DevPaks28.zip?dl=1
 
 These paks are not included in the source tree because they contains some 
 non-opensource materials and they seem too large to include in the git tree.

--- a/Sources/Client/MapView.cpp
+++ b/Sources/Client/MapView.cpp
@@ -18,6 +18,7 @@
  
  */
 
+#include "Weapon.h"
 #include "MapView.h"
 #include "IRenderer.h"
 #include "IImage.h"
@@ -30,6 +31,8 @@
 #include "../Core/Settings.h"
 
 SPADES_SETTING(cg_minimapSize, "128");
+SPADES_SETTING(cg_Minimap_Player_Color,"1");
+SPADES_SETTING(cg_Minimap_Player_Icon,"1");
 
 namespace spades {
 	namespace client {
@@ -384,6 +387,55 @@ namespace spades {
 			}
 			
 			//draw objects
+			
+			//definite a palette of 32 color in RGB code
+			int palette[32][3]={
+				{0,0,0},//0 black
+				{255,255,255},//1 white
+				{128,128,128},//2 grey
+				{255,255,0},//3 yellow
+				{0,255,255},//4 cyan-acqua
+				{255,0,255},//5 fuchsia						
+				{255,0,0},//6 red
+				{0,255,0},//7 lime
+				{0,0,255},//8 blue
+				
+				{128,0,0},//9 maroon
+				{0,128,0},//10 green
+				{0,0,128},//11 navy
+				{128,128,0},//12 olive
+				{128,0,128},//13 purple
+				{0,128,128},//14 teal
+				
+				{255,128,0},//15 orange
+				{255,0,128},//16 deep pink
+				{128,0,255},//17 violet
+				{0,128,255},//18 bluette
+				{128,255,0},//19 lime 2
+				{0,255,128},//20 spring green
+				
+				{255,128,128},//21 light pink
+				{128,255,128},//22 light spring
+				{128,128,255},//23 light blue			
+				{128,255,255},//24 light azure
+				{255,255,128},//25 light yellow
+				{255,128,255},//26 light pink2
+				
+				{165,42,42},//27 brown
+				{255,69,0},//28 orange	red
+				{255,165,0},//29  orange
+				{139,69,19},//30 maroon medium
+				{210,105,30},//31 choccolate
+						
+						
+			};
+			
+			std::string iconmode = cg_Minimap_Player_Icon;//import variable from configuration file
+			std::string colormode = cg_Minimap_Player_Color;//import variable from configuration file
+			
+			Handle<IImage> playerSMG = renderer->RegisterImage("Gfx/Map/SMG.png");
+			Handle<IImage> playerRifle = renderer->RegisterImage("Gfx/Map/Rifle.png");
+			Handle<IImage> playerShotgun = renderer->RegisterImage("Gfx/Map/Shotgun.png");
 			Handle<IImage> playerIcon = renderer->RegisterImage("Gfx/Map/Player.png");
 			
 			{
@@ -428,12 +480,43 @@ namespace spades {
 						ang = client->followYaw - static_cast<float>(M_PI) * .5f;
 					}
 					
+					//use a spec color for each player
+					if ( colormode=="1"){
+						IntVector3 Colorplayer=IntVector3::Make(palette[i][0],palette[i][1],palette[i][2]);
+						Vector4 ColorplayerF = ModifyColor(Colorplayer);
+						ColorplayerF *=1.0f;
+						renderer->SetColorAlphaPremultiplied(ColorplayerF);
+					}	
+					else {
+						renderer->SetColorAlphaPremultiplied(teamColorF);
+					}
 					
-					renderer->SetColorAlphaPremultiplied(teamColorF);
-					
-					DrawIcon(player->GetTeamId() >= 2 ?
-							 client->followPos :
-							 p->GetPosition(), playerIcon, ang);
+					//use a different icon in minimap according to weapon of player
+					if( iconmode=="1"){
+						std::string weapon=world->GetPlayer(i)->GetWeapon()->GetName();
+						if (weapon=="SMG"){							
+							DrawIcon(player->GetTeamId() >= 2 ?
+									client->followPos :
+									p->GetPosition(),playerSMG , ang);
+						}
+						
+						else if (weapon=="Rifle"){
+							DrawIcon(player->GetTeamId() >= 2 ?
+									client->followPos :
+									p->GetPosition(), playerRifle, ang);
+						}
+						
+						else if (weapon=="Shotgun"){
+							DrawIcon(player->GetTeamId() >= 2 ?
+									client->followPos :
+									p->GetPosition(), playerShotgun, ang);
+						}
+					}
+					else{//draw normal color	
+						DrawIcon(player->GetTeamId() >= 2 ?
+								client->followPos :
+								p->GetPosition(), playerIcon, ang);
+					}
 				}
 			}
 			
@@ -497,3 +580,4 @@ namespace spades {
 		}
 	}
 }
+ 

--- a/Sources/Client/ScoreboardView.cpp
+++ b/Sources/Client/ScoreboardView.cpp
@@ -303,7 +303,7 @@ namespace spades {
 					IntVector3 Colorplayer=IntVector3::Make(palette[i][0],palette[i][1],palette[i][2]);
 					Vector4 ColorplayerF = ModifyColor(Colorplayer);
 					ColorplayerF *=1.0f;
-					font->Draw(buf, MakeVector2(colX + 35.f - size.x,rowY),1.f, changeF);
+					font->Draw(buf, MakeVector2(colX + 35.f - size.x,rowY),1.f, ColorplayerF);
 				}	
 				else {
 						font->Draw(buf, MakeVector2(colX + 35.f - size.x,rowY),1.f, color);

--- a/Sources/Client/ScoreboardView.cpp
+++ b/Sources/Client/ScoreboardView.cpp
@@ -34,6 +34,9 @@
 #include "TCGameMode.h"
 #include "NetClient.h"
 #include <Core/Strings.h>
+#include "../Core/Settings.h"
+
+SPADES_SETTING(cg_Minimap_Player_Color,"1");
 
 namespace spades {
 	namespace client {
@@ -241,6 +244,50 @@ namespace spades {
 			int row = 0, col = 0;
 			float colWidth = (float)width / (float)cols;
 			
+			//definite a palette of 32 color in RGB code
+			int palette[32][3]={
+						{0,0,0},//0 black
+						{255,255,255},//1 white
+						{128,128,128},//2 grey
+						{255,255,0},//3 yellow
+						{0,255,255},//4 cyan-acqua
+						{255,0,255},//5 fuchsia						
+						{255,0,0},//6 red
+						{0,255,0},//7 lime
+						{0,0,255},//8 blue
+						
+						{128,0,0},//9 maroon
+						{0,128,0},//10 green
+						{0,0,128},//11 navy
+						{128,128,0},//12 olive
+						{128,0,128},//13 purple
+						{0,128,128},//14 teal
+						
+						{255,128,0},//15 orange
+						{255,0,128},//16 deep pink
+						{128,0,255},//17 violet
+						{0,128,255},//18 bluette
+						{128,255,0},//19 lime 2
+						{0,255,128},//20 spring green
+						
+						{255,128,128},//21 light pink
+						{128,255,128},//22 light spring
+						{128,128,255},//23 light blue			
+						{128,255,255},//24 light azure
+						{255,255,128},//25 light yellow
+						{255,128,255},//26 light pink2
+						
+						{165,42,42},//27 brown
+						{255,69,0},//28 orange	red
+						{255,165,0},//29  orange
+						
+						{139,69,19},//30 maroon medium
+						{210,105,30},//31 choccolate
+						
+			};
+
+			std::string colormode = cg_Minimap_Player_Color;
+			
 			for(int i = 0; i < numPlayers; i++){
 				ScoreboardEntry& ent = entries[i];
 				
@@ -251,10 +298,16 @@ namespace spades {
 					color = GetTeamColor(team);
 				
 				sprintf(buf, "#%d", ent.id); // FIXME: 1-base?
-				size = font->Measure(buf);
-				font->Draw(buf, MakeVector2(colX + 35.f - size.x,
-											rowY),
-						   1.f, color);
+				size = font->Measure(buf);				
+				if ( colormode=="1"){
+					IntVector3 Colorplayer=IntVector3::Make(palette[i][0],palette[i][1],palette[i][2]);
+					Vector4 ColorplayerF = ModifyColor(Colorplayer);
+					ColorplayerF *=1.0f;
+					font->Draw(buf, MakeVector2(colX + 35.f - size.x,rowY),1.f, changeF);
+				}	
+				else {
+						font->Draw(buf, MakeVector2(colX + 35.f - size.x,rowY),1.f, color);
+				}
 				
 				font->Draw(ent.name, MakeVector2(colX + 45.f,
 											rowY),


### PR DESCRIPTION
As you can see on the forum at:
http://www.buildandshoot.com/viewtopic.php?f=57&t=12640
i have make some improvements to the minimap. All the options can be enabled/disable in the config page by turning to 1 or 0 the 2 voices:
cg_Minimap_Player_Icon : allow the player to see the other player weapon rapresented in the minimap by 3 different icon.
cg_Minimap_Player_Color: allow the client to see all the players rapresented by a unique color.

For this purpose I had to add 3 icons within DevPaks27.zip, so now the package is in another place and is called DevPaks28.zip.

In any case everything works fine.
I hope you will accept my contribution, if you do not like tell me something, change it immediately.