### PR TITLE
Server Disconnect Screen

### DIFF
--- a/Resources/Locales/de/openspades.po
+++ b/Resources/Locales/de/openspades.po
@@ -1649,3 +1649,8 @@ msgstr "Warte auf Status"
 msgctxt "Preferences"
 msgid "Show Statistics"
 msgstr "Zeige Statistiken"
+
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr "Trennen gerade vom server..."

--- a/Resources/Locales/ja/openspades.po
+++ b/Resources/Locales/ja/openspades.po
@@ -1757,3 +1757,8 @@ msgstr "レンズ効果"
 msgctxt "StartupScreen"
 msgid "Simulates distortion caused by a real camera lens."
 msgstr "現実世界のレンズの歪みをシミュレートします。"
+
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr "サーバーから切断"

--- a/Resources/Locales/ko/openspades.po
+++ b/Resources/Locales/ko/openspades.po
@@ -1766,3 +1766,8 @@ msgstr "상태 기다리는 중"
 msgctxt "Preferences"
 msgid "Show Statistics"
 msgstr "통계 보이기"
+
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr "서버에서 분리"

--- a/Resources/Locales/pl_PL/pl_PL
+++ b/Resources/Locales/pl_PL/pl_PL
@@ -1675,3 +1675,7 @@ msgctxt "StartupScreen"
 msgid "Simulates distortion caused by a real camera lens."
 msgstr "Symuluje zniekształcenie powodowane przez prawdziwe obiektywy."
 
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr "Odłączanie od serwer..."

--- a/Resources/Locales/pot/openspades.pot
+++ b/Resources/Locales/pot/openspades.pot
@@ -1704,3 +1704,8 @@ msgstr ""
 msgctxt "StartupScreen"
 msgid "Simulates distortion caused by a real camera lens."
 msgstr ""
+
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr ""

--- a/Resources/Locales/ru/openspades.po
+++ b/Resources/Locales/ru/openspades.po
@@ -1767,3 +1767,8 @@ msgstr "Эффекты линзы"
 msgctxt "StartupScreen"
 msgid "Simulates distortion caused by a real camera lens."
 msgstr "Симулирует искажения, вызванные линзами реальной камеры."
+
+#: ../../../Sources/Client/Client_Draw.cpp:232
+msgctxt "Client"
+msgid "Disconnecting..."
+msgstr "Отключение..."

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -210,6 +210,9 @@ namespace spades {
 			SPADES_MARK_FUNCTION();
 			
 			NetLog("Disconnecting");
+
+			DrawDisconnectScreen();
+
 			if(logStream) {
 				SPLog("Closing netlog");
 				logStream.reset();

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -240,6 +240,7 @@ namespace spades {
 			
 			void DrawSplash();
 			void DrawStartupScreen();
+			void DrawDisconnectScreen();
 			void DoInit();
 			
 			void ShowAlert(const std::string& contents,

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -213,6 +213,29 @@ namespace spades {
 			renderer->Flip();
 		}
 		
+		void Client::DrawDisconnectScreen() {
+			Handle<client::IImage> img;
+			Vector2 scrSize = { renderer->ScreenWidth(),
+				renderer->ScreenHeight() };
+
+			renderer->SetColorAlphaPremultiplied(MakeVector4(0, 0, 0, 1.));
+			img = renderer->RegisterImage("Gfx/White.tga");
+			renderer->DrawImage(img, AABB2(0, 0,
+				scrSize.x, scrSize.y));
+
+			DrawSplash();
+
+			IFont *font = textFont;
+			std::string str = _Tr("Client", "Disconnecting...");
+			Vector2 size = font->Measure(str);
+			Vector2 pos = MakeVector2(scrSize.x - 16.f, scrSize.y - 16.f);
+			pos -= size;
+			font->DrawShadow(str, pos, 1.f, MakeVector4(1, 1, 1, 1), MakeVector4(0, 0, 0, 0.5));
+
+			renderer->FrameDone();
+			renderer->Flip();
+		}
+		
 		void Client::DrawHurtSprites() {
 			float per = (world->GetTime() - lastHurtTime) / 1.5f;
 			if(per > 1.f) return;


### PR DESCRIPTION
Implemented a screen shown when the client disconnects from a server, which may be preferable to the frozen game render that is shown currently.  The screen consists of the OpenSpades logo and a "Disconnecting" message in the lower right.  I also added translation entries for the new message.  My translations are almost certainly not 100% accurate, so a double-check will be necessary.

Change summary follows.

**Sources/Client/Client.cpp:**
  + Added call to Client::DrawDisconnectScreen() in client destructor

**Sources/Client/Client.h:**
  + Added new prototype Client::DrawDisconnectScreen()

**Sources/Client/Client_Draw.cpp:**
  + Added function declaration for Client::DrawDisconnectScreen()
  * New Localization Introduced: "Client":"Disconnecting..."

**Resources/de/openspades.po:**
  + Added rudimentary German translation for "Client":"Disconnecting..."

**Resources/ja/openspades.po:**
  + Added rudimentary Japanese translation for "Client":"Disconnecting..."

**Resources/ko/openspades.po:**
  + Added rudimentary Korean translation for "Client":"Disconnecting..."

**Resources/pl_PL/pl_PL:**
  + Added rudimentary Polish translation for "Client":"Disconnecting..."

**Resources/pot/openspades.pot:**
  + Added translation entry for "Client":"Disconnecting..."

**Resources/ru/openspades.po:**
  + Added rudimentary Russian translation for "Client":"Disconnecting..."