### PR TITLE
Revert "#373 Fill weapon clip when ammo is restocked."

### DIFF
--- a/Sources/Client/Weapon.cpp
+++ b/Sources/Client/Weapon.cpp
@@ -51,7 +51,6 @@ namespace spades {
 		
 		void Weapon::Restock() {
 			stock = GetMaxStock();
-			ammo = GetClipSize();
 		}
 		
 		void Weapon::Reset() {


### PR DESCRIPTION
Reverts yvt/openspades#374

See https://github.com/NateShoffner/PySnip/blob/d094fb8231829ec4075ae190139587dad98b0371/pyspades/weapon.py for vanilla behavior.