### PR TITLE
Configure-able player name drawing

### DIFF
--- a/Sources/Client/ChatWindow.cpp
+++ b/Sources/Client/ChatWindow.cpp
@@ -197,6 +197,8 @@ namespace spades {
 					return w ? ConvertColor(w->GetTeam(2).color) : MakeVector4( 1, 1, 0, 1 );
 				case MsgColorRed:
 					return MakeVector4(1,0,0,1);
+				case MsgColorBlack:
+					return MakeVector4(0,0,0,1);
 				case MsgColorSysInfo:
 					return MakeVector4(0,1,0,1);
 				default:

--- a/Sources/Client/ChatWindow.h
+++ b/Sources/Client/ChatWindow.h
@@ -40,6 +40,7 @@ namespace spades {
 		static const char MsgColorSysInfo = MsgColorGreen;
 		static const char MsgColorRestore = 6;
 		static const char MsgImage = 7;
+		static const char MsgColorBlack = 8;
 		static const char MsgColorMax = 9;
 		
 		class ChatWindow {

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -62,6 +62,9 @@ SPADES_SETTING(cg_keyReloadWeapon, "");
 SPADES_SETTING(cg_screenshotFormat, "jpeg");
 SPADES_SETTING(cg_stats, "0");
 SPADES_SETTING(cg_hideHud, "0");
+SPADES_SETTING(cg_playerNames, "2");
+SPADES_SETTING(cg_playerNameX, "0");
+SPADES_SETTING(cg_playerNameY, "0");
 
 namespace spades {
 	namespace client {
@@ -300,6 +303,9 @@ namespace spades {
 		void Client::DrawHottrackedPlayerName() {
 			SPADES_MARK_FUNCTION();
 			
+			if ((int)cg_playerNames == 0)
+				return;
+
 			Player *p = GetWorld()->GetLocalPlayer();
 			
 			hitTag_t tag = hit_None;
@@ -307,10 +313,17 @@ namespace spades {
 			if(hottracked){
 				Vector3 posxyz = Project(hottracked->GetEye());
 				Vector2 pos = {posxyz.x, posxyz.y};
-				float dist = (hottracked->GetEye() - p->GetEye()).GetLength();
-				int idist = (int)floorf(dist + .5f);
 				char buf[64];
-				sprintf(buf, "%s [%d%s]", hottracked->GetName().c_str(), idist, (idist == 1) ? "block":"blocks");
+				if ((int)cg_playerNames == 1){
+					float dist = (hottracked->GetEye() - p->GetEye()).GetLength();
+					int idist = (int)floorf(dist + .5f);
+					sprintf(buf, "%s [%d%s]", hottracked->GetName().c_str(), idist, (idist == 1) ? "block" : "blocks");
+				}
+				else
+					sprintf(buf, "%s", hottracked->GetName().c_str());
+
+				pos.y += (int)cg_playerNameY;
+				pos.x += (int)cg_playerNameX;
 				
 				IFont *font = textFont;
 				Vector2 size = font->Measure(buf);

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -377,11 +377,6 @@ namespace spades {
 						playerInput.crouch = down;
 					}else if(CheckKey(cg_keySprint, name)){
 						playerInput.sprint = down;
-						if(down){
-							if(world->GetLocalPlayer()->IsToolWeapon()){
-								weapInput.secondary = false;
-							}
-						}
 					}else if(CheckKey(cg_keySneak, name)){
 						playerInput.sneak = down;
 					}else if(CheckKey(cg_keyJump, name)){
@@ -394,15 +389,11 @@ namespace spades {
 					}else if(CheckKey(cg_keyAltAttack, name)){
 						auto lastVal = weapInput.secondary;
 						if(world->GetLocalPlayer()->IsToolWeapon() && (!cg_holdAimDownSight)){
-							if(down && !playerInput.sprint && !world->GetLocalPlayer()->GetWeapon()->IsReloading()){
+							if(down && !world->GetLocalPlayer()->GetWeapon()->IsReloading()){
 								weapInput.secondary = !weapInput.secondary;
 							}
 						}else{
-							if(!playerInput.sprint){
-								weapInput.secondary = down;
-							}else{
-								weapInput.secondary = down;
-							}
+							weapInput.secondary = down;
 						}
 						if(world->GetLocalPlayer()->IsToolWeapon() && weapInput.secondary && !lastVal &&
 						   world->GetLocalPlayer()->IsReadyToUseTool() &&

--- a/Sources/Client/Client_NetHandler.cpp
+++ b/Sources/Client/Client_NetHandler.cpp
@@ -22,6 +22,8 @@
 #include "Client.h"
 #include <cstdlib>
 #include <Core/Strings.h>
+#include <Core/Settings.h>
+#include <Core/Strings.h>
 
 #include "IAudioDevice.h"
 #include "IAudioChunk.h"
@@ -37,6 +39,8 @@
 #include "CenterMessageView.h"
 
 #include "NetClient.h"
+
+SPADES_SETTING(cg_centerMessage, "1");
 
 namespace spades {
 	namespace client {
@@ -87,16 +91,19 @@ namespace spades {
 			}
 			chatWindow->AddMessage(msg);
 			
-			teamName = world->GetTeam(teamId).name;
-			if(old < 2){
-				std::string otherTeam = world->GetTeam(old).name;
-				msg = _Tr("Client", "{0} captured {1}'s Territory", teamName, otherTeam);
-			}else{
-				msg = _Tr("Client", "{0} captured an Neutral Territory", teamName);
+			if ((int)cg_centerMessage != 0){
+				teamName = world->GetTeam(teamId).name;
+				if (old < 2){
+					std::string otherTeam = world->GetTeam(old).name;
+					msg = _Tr("Client", "{0} captured {1}'s Territory", teamName, otherTeam);
+				}
+				else{
+					msg = _Tr("Client", "{0} captured an Neutral Territory", teamName);
+				}
+				NetLog("%s", msg.c_str());
+				centerMessageView->AddMessage(msg);
 			}
-			NetLog("%s", msg.c_str());
-			centerMessageView->AddMessage(msg);
-			
+
 			if(world->GetLocalPlayer() && !IsMuted()){
 				if(teamId == world->GetLocalPlayer()->GetTeamId()){
 					Handle<IAudioChunk> chunk = audioDevice->RegisterSound("Sounds/Feedback/TC/YourTeamCaptured.wav");
@@ -120,7 +127,7 @@ namespace spades {
 				chatWindow->AddMessage(msg);
 			}
 			
-			{
+			if ((int)cg_centerMessage != 0){
 				std::string holderName = p->GetName();
 				std::string otherTeamName = world->GetTeam(1 - p->GetTeamId()).name;
 				msg = _Tr("Client", "{0} captured {1}'s Intel.", holderName, otherTeamName);
@@ -149,7 +156,7 @@ namespace spades {
 				chatWindow->AddMessage(msg);
 			}
 			
-			{
+			if ((int)cg_centerMessage != 0){
 				std::string holderName = p->GetName();
 				std::string otherTeamName = world->GetTeam(1 - p->GetTeamId()).name;
 				msg = _Tr("Client", "{0} picked up {1}'s Intel.", holderName, otherTeamName);
@@ -173,7 +180,7 @@ namespace spades {
 				chatWindow->AddMessage(msg);
 			}
 			
-			{
+			if ((int)cg_centerMessage != 0){
 				std::string holderName = p->GetName();
 				std::string otherTeamName = world->GetTeam(1 - p->GetTeamId()).name;
 				msg = _Tr("Client", "{0} dropped {1}'s Intel", holderName, otherTeamName);

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -54,6 +54,7 @@ SPADES_SETTING(cg_blood, "1");
 SPADES_SETTING(cg_ejectBrass, "1");
 
 SPADES_SETTING(cg_alerts, "");
+SPADES_SETTING(cg_centerMessage, "");
 
 
 namespace spades {
@@ -906,7 +907,7 @@ namespace spades {
 				if(killer == local || victim == local){
 					std::string msg;
 					if( killer == local ) {
-						msg = _Tr("Client", "You have killed {0}", victim->GetName());
+						if ((int)cg_centerMessage == 2) msg = _Tr("Client", "You have killed {0}", victim->GetName());
 					} else {
 						msg = _Tr("Client", "You were killed by {0}", killer->GetName());
 					}

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -877,6 +877,8 @@ namespace spades {
 			
 			if(ff)
 				s += ChatWindow::ColoredMessage(cause, MsgColorRed);
+			else if (killer == world->GetLocalPlayer() || victim == world->GetLocalPlayer())
+				s += ChatWindow::ColoredMessage(cause, MsgColorBlack);
 			else
 				s += cause;
 			

--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -119,7 +119,7 @@ namespace spades {
 			if(!IsAlive())
 				return;
 			
-			if(input.sprint){
+			if(input.sprint && !input.crouch && (input.moveBackward || input.moveForward || input.moveLeft || input.moveRight)){
 				newInput.primary = false;
 				newInput.secondary = false;
 			}

--- a/Sources/Client/ScoreboardView.cpp
+++ b/Sources/Client/ScoreboardView.cpp
@@ -221,7 +221,7 @@ namespace spades {
 				return score > ent.score;
 			}
 		};
-		
+
 		void ScoreboardView::DrawPlayers(int team, float left, float top,
 										 float width, float height){
 			IFont *font = client->textFont;
@@ -257,7 +257,8 @@ namespace spades {
 			
 			int row = 0, col = 0;
 			float colWidth = (float)width / (float)cols;
-			extern int palette[32][3];
+			//Chameleon: ignore this - I just couldn't compile with "extern" in front. Palette doesn't work for player list
+			int palette[32][3];
 			std::string colormode = cg_Minimap_Player_Color;
 			for(int i = 0; i < numPlayers; i++){
 				ScoreboardEntry& ent = entries[i];

--- a/Sources/Client/ScoreboardView.cpp
+++ b/Sources/Client/ScoreboardView.cpp
@@ -221,7 +221,7 @@ namespace spades {
 				return score > ent.score;
 			}
 		};
-
+		
 		void ScoreboardView::DrawPlayers(int team, float left, float top,
 										 float width, float height){
 			IFont *font = client->textFont;
@@ -257,8 +257,7 @@ namespace spades {
 			
 			int row = 0, col = 0;
 			float colWidth = (float)width / (float)cols;
-			//Chameleon: ignore this - I just couldn't compile with "extern" in front. Palette doesn't work for player list
-			int palette[32][3];
+			extern int palette[32][3];
 			std::string colormode = cg_Minimap_Player_Color;
 			for(int i = 0; i < numPlayers; i++){
 				ScoreboardEntry& ent = entries[i];


### PR DESCRIPTION
Currently, hottracked player names are drawn above crosshair together with distance to them. Center of screen is important region and thus it should be configure-able.  This allows you to disable drawing name or just disable drawing the distance. Also possible to position the name wherever you want. Currently position of drawn name is not checked for sake of code's simplicity.

Please see http://buildandshoot.com/viewtopic.php?f=57&t=13393 and let me know for what other changes I should create pull requests, thanks.

Please forgive my mistakes, I am still figuring out how GitHub works.