### PR TITLE
Updated spectator behavior.

### DIFF
--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -138,7 +138,7 @@ namespace spades {
 			KeypadInput keypadInput;
 			Player::ToolType lastTool;
 			bool hasLastTool;
-			bool FirstPersonSpectate;
+			int spectateMode;
 			Vector3 lastFront;
 			float lastPosSentTime;
 			int lastHealth;

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -797,10 +797,10 @@ namespace spades {
 						// just spectating
 					}else{
 						font = textFont;
-						std::string msg = _Tr("Client", "Following {0}", world->GetPlayerPersistent(followingPlayerId).name);
+						std::string msg = _Tr("Client", "Following {0} | ID: #{1}", world->GetPlayerPersistent(followingPlayerId).name, followingPlayerId);
 						Vector2 size = font->Measure(msg);
-						Vector2 pos = MakeVector2(scrWidth - 8.f, 256.f + 32.f);
-						pos.x -= size.x;
+						Vector2 pos = MakeVector2(scrWidth/2.f, 16.f);
+						pos.x -= size.x/2.f;
 						font->DrawShadow(msg, pos, 1.f, MakeVector4(1, 1, 1, 1), MakeVector4(0,0,0,0.5));
 					}
 				}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -95,7 +95,7 @@ namespace spades {
 			return readyToClose;
 		}
 		
-		bool FirstPersonSpectate = false;
+		bool spectateMode = 1;
 		
 		void Client::Closing() {
 			SPADES_MARK_FUNCTION();
@@ -319,11 +319,8 @@ namespace spades {
 						return;
 					}else if(CheckKey(cg_keyAltAttack, name)){
 						if(down){
-							if(world->GetLocalPlayer()->GetTeamId() >= 2) {
-								// spectating
-								followingPlayerId = world->GetLocalPlayerIndex();
-							}else if(time > lastAliveTime + 1.3f){
-								// dead
+							if(world->GetLocalPlayer()->GetTeamId() >= 2 || time > lastAliveTime + 1.3f) {
+								// spectating or dead
 								FollowNextPlayer(true);
 							}
 						}
@@ -381,8 +378,24 @@ namespace spades {
 					}else if(CheckKey(cg_keySneak, name)){
 						playerInput.sneak = down;
 					}else if(CheckKey(cg_keyJump, name)){
-						if(down){
-							FirstPersonSpectate = !FirstPersonSpectate;
+						if(down){ // cycle through spectate modes: 0 (free), 1 (follow), and 2 (first person)
+							if(world && world->GetLocalPlayer()) {
+								if(world->GetLocalPlayer()->GetTeamId() < 2) { // if we're NOT spectator, flip flop between 1 and 2 (follow, and first)
+									if(spectateMode <= 1) {
+										spectateMode = 2;
+									} else {
+										spectateMode =1;
+									}
+								} else { // otherwise, cycle through the three modes as usual
+									if (spectateMode <= 0) {
+										spectateMode = 1;
+									} else if (spectateMode == 1) {
+										spectateMode = 2;
+									} else {
+										spectateMode = 0;
+									} 
+								}
+							}
 						}
 						playerInput.jump = down;
 					}else if(CheckKey(cg_keyAttack, name)){

--- a/Sources/Client/Client_Scene.cpp
+++ b/Sources/Client/Client_Scene.cpp
@@ -129,17 +129,17 @@ namespace spades {
 					player = world->GetPlayer(followingPlayerId);
 				}
 				if(player){
-					
 					float roll = 0.f;
 					float scale = 1.f;
 					float vibPitch = 0.f;
 					float vibYaw = 0.f;
+					// if we're dead, or if we're following a player other than ourself AND we're not in free mode, then
 					if(ShouldRenderInThirdPersonView() ||
-					   (IsFollowing() && player != world->GetLocalPlayer())){
+					   (IsFollowing() && spectateMode != 0 && player != world->GetLocalPlayer())){
 						Vector3 center = player->GetEye();
 						Vector3 playerFront = player->GetFront2D();
 						Vector3 up = MakeVector3(0,0,-1);
-						
+
 						if((!player->IsAlive()) && lastMyCorpse &&
 						   player == world->GetLocalPlayer()){
 							center = lastMyCorpse->GetCenter();
@@ -201,12 +201,12 @@ namespace spades {
 						Vector3 front = center - eye;
 						front = front.Normalize();
 						
-						if(FirstPersonSpectate == false){
+						if(spectateMode != 2){ // if we're NOT in first person
 							def.viewOrigin = eye;
 							def.viewAxis[0] = -Vector3::Cross(up, front).Normalize();
 							def.viewAxis[1] = -Vector3::Cross(front, def.viewAxis[0]).Normalize();
 							def.viewAxis[2] = front;
-						}else{
+						}else{ // otherwise, dispose of all the calculations we did and set it to the view of the player we're watching
 							def.viewOrigin = player->GetEye();
 							def.viewAxis[0] = player->GetRight();
 							def.viewAxis[1] = player->GetUp();
@@ -224,8 +224,9 @@ namespace spades {
 						// longer following
 						followPos = def.viewOrigin;
 						followVel = MakeVector3(0, 0, 0);
-						
-					}else if(player->GetTeamId() >= 2){
+					
+					// else, if we are currently watching a spectator or we are a spectator ourself then
+					}else if(player->GetTeamId() >= 2 || world->GetLocalPlayer()->GetTeamId() >= 2){
 						// spectator view (noclip view)
 						Vector3 center = followPos;
 						Vector3 front;


### PR DESCRIPTION
When spectating, primary and secondary fire (default left and right click)
now go to the next and previous player, respectively. I did this so that the
spectator doesn't have to cycle through all the players again when he/she
"overshoots" by spamming click too much.

The button to cycle through modes is now jump (default spacebar). it goes
from "free", to "follow", to "first person". If the player is not on the spectator
team, then skips through free automatically.

Lastly, I moved the "Following {playername}" text to the top of the screen.
I also added the player's ID#. This is useful if you're spectating a possible
cheater and you need to report its ID#.