### PR TITLE
Add *.mo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ openspades.mk/
 # fltk / fluid output leftovers
 Sources/Gui/DetailConfigWindow.txt
 Sources/Gui/MainWindow.txt
+
+# Compiled .mo files (translation)
+*.mo


### PR DESCRIPTION
.mo files are binary files automatically generated by Poedit during translation.