### PR TITLE
Move [Build Status] next to repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# OpenSpades
-[![Build status](https://travis-ci.org/yvt/openspades.png?branch=master)](https://travis-ci.org/yvt/openspades)
+# OpenSpades [![Build status](https://travis-ci.org/yvt/openspades.png?branch=master)](https://travis-ci.org/yvt/openspades)
 
 ![OpenSpades banner](https://dl.dropboxusercontent.com/u/37804131/github/OpenSpadesBanner.jpg)
 


### PR DESCRIPTION
Cause Build Status in current place just looks weird