### PR TITLE
Fix compilation on newer libstdc++.

### DIFF
--- a/Sources/Client/Client_Scene.cpp
+++ b/Sources/Client/Client_Scene.cpp
@@ -438,9 +438,9 @@ namespace spades {
 				def.zFar -= def.viewOrigin.z;
 			}
 
-			SPAssert(!isnan(def.viewOrigin.x));
-			SPAssert(!isnan(def.viewOrigin.y));
-			SPAssert(!isnan(def.viewOrigin.z));
+			SPAssert(!std::isnan(def.viewOrigin.x));
+			SPAssert(!std::isnan(def.viewOrigin.y));
+			SPAssert(!std::isnan(def.viewOrigin.z));
 
 			def.radialBlur = std::min(def.radialBlur, 1.f);
 

--- a/Sources/Client/GameMap.cpp
+++ b/Sources/Client/GameMap.cpp
@@ -197,16 +197,16 @@ namespace spades {
 		}
 
 		bool GameMap::ClipBox(float x, float y, float z) {
-			SPAssert(!isnan(x));
-			SPAssert(!isnan(y));
-			SPAssert(!isnan(z));
+			SPAssert(!std::isnan(x));
+			SPAssert(!std::isnan(y));
+			SPAssert(!std::isnan(z));
 			return ClipBox((int)floorf(x), (int)floorf(y), (int)floorf(z));
 		}
 
 		bool GameMap::ClipWorld(float x, float y, float z) {
-			SPAssert(!isnan(x));
-			SPAssert(!isnan(y));
-			SPAssert(!isnan(z));
+			SPAssert(!std::isnan(x));
+			SPAssert(!std::isnan(y));
+			SPAssert(!std::isnan(z));
 			return ClipWorld((int)floorf(x), (int)floorf(y), (int)floorf(z));
 		}
 
@@ -214,13 +214,13 @@ namespace spades {
 		                      spades::IntVector3 &vOut) {
 			SPADES_MARK_FUNCTION_DEBUG();
 
-			SPAssert(!isnan(v0.x));
-			SPAssert(!isnan(v0.y));
-			SPAssert(!isnan(v0.z));
-			SPAssert(!isnan(v1.x));
-			SPAssert(!isnan(v1.y));
-			SPAssert(!isnan(v1.z));
-			SPAssert(!isnan(length));
+			SPAssert(!std::isnan(v0.x));
+			SPAssert(!std::isnan(v0.y));
+			SPAssert(!std::isnan(v0.z));
+			SPAssert(!std::isnan(v1.x));
+			SPAssert(!std::isnan(v1.y));
+			SPAssert(!std::isnan(v1.z));
+			SPAssert(!std::isnan(length));
 
 			v1 = v0 + v1 * length;
 
@@ -368,12 +368,12 @@ namespace spades {
 			SPADES_MARK_FUNCTION_DEBUG();
 			GameMap::RayCastResult result;
 
-			SPAssert(!isnan(v0.x));
-			SPAssert(!isnan(v0.y));
-			SPAssert(!isnan(v0.z));
-			SPAssert(!isnan(dir.x));
-			SPAssert(!isnan(dir.y));
-			SPAssert(!isnan(dir.z));
+			SPAssert(!std::isnan(v0.x));
+			SPAssert(!std::isnan(v0.y));
+			SPAssert(!std::isnan(v0.z));
+			SPAssert(!std::isnan(dir.x));
+			SPAssert(!std::isnan(dir.y));
+			SPAssert(!std::isnan(dir.z));
 
 			dir = dir.Normalize();
 

--- a/Sources/Draw/GLRadiosityRenderer.cpp
+++ b/Sources/Draw/GLRadiosityRenderer.cpp
@@ -270,7 +270,7 @@ namespace spades {
 					result.y += color * normDiff.y;
 					result.z += color * normDiff.z;
 
-					SPAssert(!isnan(intensity));
+					SPAssert(!std::isnan(intensity));
 					SPAssert(intensity >= 0.f);
 					SPAssert(red >= 0.f && red < 64.f);
 					SPAssert(green >= 0.f && green < 64.f);


### PR DESCRIPTION
Newer versions only declare isnan in the std namespace when the cmath header is used.