### PR TITLE
Support pak creation with Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ GCC 4.9 / Clang 3.2 or later is recommended because OpenSpades relies on C++11 f
 ### On Windows (with Visual Studio)
 1. Get the required software.
   * CMake 2.8+
+  * PowerShell 5.0
+    * Integrated with Windows 10.
+    * Older versions are not tested, but might work
   * *Visual Studio 2015* 
     * VS2013 is no longer supported, but might work
 2. Grab the source code:
@@ -113,13 +116,7 @@ GCC 4.9 / Clang 3.2 or later is recommended because OpenSpades relies on C++11 f
    
    Source: `E:/Projects/openspades`,
    Binaries: `E:/Projects/openspades/OpenSpades.msvc`
-   Generator: Visual Studio 12 (2013) or 14 (2015) (not Win64!)
-   
-   For your convenience, create the directory: `E:/Projects/openspades/OpenSpades.msvc/os.Resources`, and extract the [Non-free pak](https://dl.dropboxusercontent.com/u/37804131/openspades/DevPaks29.zip) (`pak000-Nonfree.pak`) into it. Also, please note you can't distribute this pak separately from OpenSpades releases or binaries, as noted on `Resources/PakLocation.txt`
-   
-   set `OPENSPADES_RESDIR` to point to `os.Resources`. (Run CMake again, now when running debug builds openspades will also read resources from this directory)
-   
-   **Note:** `OPENSPADES_RESDIR` must be set using slashes instead of backslashes (`E:/Projects/openspades/os.Resources` instead of `E:\Projects\openspades\os.Resources`). Also, no slashes at end.
+   Generator: Visual Studio 14 (2015) (not Win64!)
    
 6. Open `E:/Projects/openspades/OpenSpades.msvc/OpenSpades.sln` in Visual Studio.
 7. Build the solution.
@@ -128,9 +125,7 @@ GCC 4.9 / Clang 3.2 or later is recommended because OpenSpades relies on C++11 f
 
     **Note:** In case OpenSpades still fails to find any dll, copy all the remaing dlls which aren't there yet, it should solve the problem.
     
-10. Copy `E:/Projects/openspades/Resources` folder to your build directory, which is probably `E:/Projects/openspades/openspades.msvc/bin/BUILD_TYPE`
-
-    In case you haven't set OPENSPADES_RESDIR and extracted the [Non-free pak](https://dl.dropboxusercontent.com/u/37804131/openspades/DevPaks29.zip) into it, extract it and merge it inside the `Resources` folder you just copied. You can also copy the paks contained in `Official Mods/` folder of OpenSpades 0.0.12b to add more fonts and improve localization support of your build.
+10. Download the [Non-free pak](https://dl.dropboxusercontent.com/u/37804131/openspades/DevPaks29.zip) and copy it to the `Resources` folder inside your build directory, which is probably `E:/Projects/openspades/openspades.msvc/bin/BUILD_TYPE/Resources`. You can also copy the paks contained in `Official Mods/` folder of OpenSpades 0.0.12b to add more fonts and improve localization support of your build.
 
 ### On Mac OS X (with Xcode)
 1. Get the latest version of Xcode and OpenSpades source.

--- a/Resources/CMakeLists.txt
+++ b/Resources/CMakeLists.txt
@@ -1,18 +1,51 @@
 
 if(OPENSPADES_RESOURCES)
-	add_custom_target(OpenSpades_Resources_DevPaks ALL COMMENT "Downloading non-GPL assets")
 
-	add_custom_command(
-		TARGET OpenSpades_Resources_DevPaks
-		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/downloadpak.sh
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	if (WIN32)
+		# No automatic downloading for Windows (for now)
+	elseif (UNIX)
+		add_custom_target(OpenSpades_Resources_DevPaks ALL COMMENT "Downloading non-GPL assets")
+		add_custom_command(
+			TARGET OpenSpades_Resources_DevPaks
+			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/downloadpak.sh
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	endif()
 
-	add_custom_target(OpenSpades_Resources ALL COMMENT "Packing assets")
+	# TODO: subgroups for script files
+	file(GLOB_RECURSE SCRIPT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/*.as)
+	file(GLOB_RECURSE SHADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Shaders/*.fs
+		${CMAKE_CURRENT_SOURCE_DIR}/Shaders/*.program
+		${CMAKE_CURRENT_SOURCE_DIR}/Shaders/*.vs)
 
-	add_custom_command(
-		TARGET OpenSpades_Resources
-		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/mkpak.sh
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	source_group("Scripts" FILES ${SCRIPT_FILES})
+	source_group("Shaders" FILES ${SHADER_FILES})
+
+	add_custom_target(OpenSpades_Resources ALL
+		COMMENT "Packing assets"
+		SOURCES ${SCRIPT_FILES} ${SHADER_FILES}
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR})
+
+	if(WIN32)
+		if(MSVC)
+			# multi-config
+			add_custom_command(
+				TARGET OpenSpades_Resources
+				COMMAND powershell -ExecutionPolicy Bypass ${CMAKE_CURRENT_SOURCE_DIR}/mkpak.ps1
+					${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>/Resources
+				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+		else()
+			add_custom_command(
+				TARGET OpenSpades_Resources
+				COMMAND powershell -ExecutionPolicy Bypass ${CMAKE_CURRENT_SOURCE_DIR}/mkpak.ps1
+					${CMAKE_BINARY_DIR}/bin/Resources
+				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+		endif()
+	elseif (UNIX)
+		add_custom_command(
+			TARGET OpenSpades_Resources
+			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/mkpak.sh
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+	endif()
 
 endif()
 

--- a/Resources/mkpak.ps1
+++ b/Resources/mkpak.ps1
@@ -1,0 +1,73 @@
+param([string]$OutputDirectory)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem"
+
+if ($OutputDirectory -eq "") {
+	$OutputDirectory = "."
+}
+if (-not (Test-Path $OutputDirectory)) {
+	New-Item $OutputDirectory -Force -ItemType Directory | Out-Null
+}
+
+$SourceDirectory = Split-Path -Parent $PSCommandPath
+
+function Make-Pak
+{
+	param( [String[]] $RelativePaths, [String] $PakName )
+
+	Echo "Creating $($PakName)..."
+
+	$OutputPak = Join-Path $OutputDirectory $PakName
+	
+	# Prepare a temporary directory
+	$TempDir = "mkpak.tmp"
+	if (Test-Path $TempDir) { Remove-Item $TempDir -Recurse -Force }
+	New-Item $TempDir -ItemType Directory | Out-Null
+
+	# TODO: exclude _Assets_ and .DS_Store
+
+	# Copy target files to the temporary directory
+	ForEach ($RelativePath in $RelativePaths) {
+		# Create the parent directory if it doesn't exist
+		$ParentDir = Split-Path -Parent (Join-Path $TempDir $RelativePath)
+		if (-not (Test-Path $ParentDir)) {
+			New-Item $ParentDir -Force -ItemType Directory | Out-Null
+		}
+
+		# Copy item
+		Copy-Item (Join-Path $SourceDirectory $RelativePath) `
+		  -Destination (Join-Path $TempDir $RelativePath) -Recurse
+	}
+
+	# Delete old file
+	if (Test-Path $OutputPak) { Remove-Item $OutputPak -Force }
+
+	# Create zip archive
+	# PowerShell 5 supports Compress-Archive, but the method used here is 
+	# faster by a order of magnitude for some reason.
+	# However, it's still much slower than "zip" command on Linux/macOS.
+	[IO.Compression.ZipFile]::CreateFromDirectory($TempDir, $OutputPak, 
+	  [IO.Compression.CompressionLevel]::Fastest, $false)
+
+	# Clean up
+	Remove-Item $TempDir -Recurse -Force
+}
+
+Make-Pak -PakName pak002-Base.pak -RelativePaths `
+  License/Credits-pak002-Base.md,
+  Gfx, Scripts/Main.as,
+  Scripts/Gui, Scripts/Base, Shaders, Sounds/Feedback,
+  Sounds/Misc, Sounds/Player, Textures
+
+Make-Pak -PakName pak005-Models.pak -RelativePaths `
+  Maps
+
+Make-Pak -PakName pak010-BaseSkin.pak -RelativePaths `
+  License/Credits-pak010-BaseSkin.md,
+  Scripts/Skin, Sounds/Weapons
+
+Make-Pak -PakName pak050-Locales.pak -RelativePaths `
+  License/Credits-pak050-Locales.md, Locales
+
+Make-Pak -PakName pak999-References.pak -RelativePaths `
+  License/Credits-pak999-References.md, Scripts/Reference

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -43,6 +43,17 @@ set_target_properties(OpenSpades PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BIN
 set_target_properties(OpenSpades PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(OpenSpades PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+if(WIN32)
+	# Use a single output directory for all configs
+	# (Without this, the generated binary cannot find pak files created by mkpak.ps1 unless
+	# a user explicitly specifies a search directory)
+	foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+		set_target_properties(OpenSpades PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
+		set_target_properties(OpenSpades PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
+		set_target_properties(OpenSpades PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/bin)
+	endforeach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+endif()
+
 add_dependencies(OpenSpades Angelscript Angelscript_addons)
 
 if(WIN32)


### PR DESCRIPTION
- `mkpak.sh` was ported to PowerShell (tested on PowerShell 5 integrated with Windows 10).
- `Resources/CMakeList.txt` was modified to use `mkpak.ps1` on Windows and to generate pak files in the `Resources` folder inside the build output directory.
- Fixes #316.
- `downloadpak.sh` is not ported, therefore developers still have to download the non-free pak manually.

