### PR TITLE
Add missing <intrin.h> header for Windows build

### DIFF
--- a/Sources/Core/CpuID.cpp
+++ b/Sources/Core/CpuID.cpp
@@ -1,14 +1,17 @@
 // WTFPL
 
-
 #include <cstring>
+
+// Fixes #473
+#ifdef WIN32
+	#include <intrin.h>
+#endif
 
 #include "CpuID.h"
 
 namespace spades {
 
 #if defined(__i386__) || defined(_M_IX86) || defined(__amd64__) || defined(__x86_64__)
-
 	static std::array<uint32_t, 4> cpuid(uint32_t a) {
 		std::array<uint32_t, 4> regs;
 #ifdef WIN32

--- a/Sources/Core/CpuID.h
+++ b/Sources/Core/CpuID.h
@@ -6,7 +6,7 @@
 #include <string>
 
 #if defined(__i386__) || defined(_M_IX86)
-
+	// FIXME: Why does this preprocessor condition even exists?
 #endif
 
 namespace spades {


### PR DESCRIPTION
 - Fixes VS 2017 build (#473)