### PR TITLE
Added the Portuguese language and fixed typos on POT and pt_BR

### DIFF
--- a/Resources/Locales/de/openspades.po
+++ b/Resources/Locales/de/openspades.po
@@ -1146,7 +1146,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1071
 msgctxt "StartupScreen"
 msgid ""
-"Antialias:Enables a technique to improve the appearance of high-constrast "
+"Antialias:Enables a technique to improve the appearance of high-contrast "
 "edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution "

--- a/Resources/Locales/ja/openspades.po
+++ b/Resources/Locales/ja/openspades.po
@@ -1090,7 +1090,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1126
 msgctxt "StartupScreen"
 msgid ""
-"Antialias:Enables a technique to improve the appearance of high-constrast "
+"Antialias:Enables a technique to improve the appearance of high-contrast "
 "edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution "

--- a/Resources/Locales/ko/openspades.po
+++ b/Resources/Locales/ko/openspades.po
@@ -1060,7 +1060,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1125
 msgctxt "StartupScreen"
 msgid ""
-"Antialias:Enables a technique to improve the appearance of high-constrast "
+"Antialias:Enables a technique to improve the appearance of high-contrast "
 "edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution "

--- a/Resources/Locales/pl_pl/openspades.po
+++ b/Resources/Locales/pl_pl/openspades.po
@@ -1129,7 +1129,7 @@ msgstr "Filtr"
 #: ../../Scripts/Gui/StartupScreen.as:1071
 msgctxt "StartupScreen"
 msgid ""
-"Antialias:Enables a technique to improve the appearance of high-constrast edges.\n"
+"Antialias:Enables a technique to improve the appearance of high-contrast edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution image. Looks best, but doesn't cope with some settings.\n"
 "\n"

--- a/Resources/Locales/pt_br.json
+++ b/Resources/Locales/pt_br.json
@@ -1,4 +1,4 @@
 {
-    "descriptionEnglish": "Portuguese",
-    "description": "Português"
+    "descriptionEnglish": "Portuguese (Brazil)",
+    "description": "Português (Brasil)"
 }

--- a/Resources/Locales/pt_br/openspades.po
+++ b/Resources/Locales/pt_br/openspades.po
@@ -544,7 +544,7 @@ msgstr "Ver."
 #: ../../Scripts/Gui/MainScreen.as:515 ../../Scripts/Gui/MainScreen.as:529
 msgctxt "MainScreen"
 msgid "Loc."
-msgstr "Ling."
+msgstr "Loc."
 
 #: ../../Scripts/Gui/MainScreen.as:767 ../../Scripts/Gui/MainScreen.as:787
 msgctxt "MainScreen"

--- a/Resources/Locales/pt_br/openspades.po
+++ b/Resources/Locales/pt_br/openspades.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: OpenSpades\n"
 "Report-Msgid-Bugs-To: i at yvt.jp\n"
 "POT-Creation-Date: 2016-12-07 17:52-0200\n"
-"PO-Revision-Date: 2016-12-07 18:01-0200\n"
-"Last-Translator: Flávio Monteiro <flaviomonteiro2013@gmail.com>\n"
+"PO-Revision-Date: 2016-12-10 17:55+0000\n"
+"Last-Translator: João Rodrigues <joaoadriano3@gmail.com>\n"
 "Language-Team: Portuguese Brazilian <flaviomonteiro2013@gmail.com>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -57,7 +57,7 @@ msgstr "Screenshot falhou:"
 #: ../../../Sources/Client/Client_Draw.cpp:197
 msgctxt "Client"
 msgid "NOW LOADING"
-msgstr "CARREGANDO AGORA"
+msgstr "CARREGANDO"
 
 #: ../../../Sources/Client/Client_Draw.cpp:219
 msgctxt "Client"
@@ -67,12 +67,12 @@ msgstr "Desconectando..."
 #: ../../../Sources/Client/Client_Draw.cpp:522
 msgctxt "Client"
 msgid "Out of Block"
-msgstr "Bloco acabou"
+msgstr "O bloco acabou"
 
 #: ../../../Sources/Client/Client_Draw.cpp:527
 msgctxt "Client"
 msgid "Out of Grenade"
-msgstr "Granada acabou"
+msgstr "A granada acabou"
 
 #: ../../../Sources/Client/Client_Draw.cpp:533
 msgctxt "Client"
@@ -108,12 +108,12 @@ msgstr "Seguindo {0}"
 #: ../../../Sources/Client/Client_Input.cpp:436
 msgctxt "Client"
 msgid "Out of Blocks"
-msgstr "Blocos Acabaram"
+msgstr "Os blocos acabaram"
 
 #: ../../../Sources/Client/Client_Input.cpp:460
 msgctxt "Client"
 msgid "Out of Grenades"
-msgstr "Granadas Acabaram"
+msgstr "As granadas acabaram"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:89
 msgctxt "Client"
@@ -212,7 +212,7 @@ msgstr "Você foi assassinado por {0}"
 #: ../../../Sources/Client/Client_Update.cpp:1166
 msgctxt "Client"
 msgid "Insufficient blocks."
-msgstr "blocos insuficientes."
+msgstr "Blocos insuficientes."
 
 #: ../../../Sources/Client/Client_Update.cpp:1169
 msgctxt "Client"
@@ -371,7 +371,7 @@ msgstr "Erro Fatal no OpenSpades"
 #: ../../../Sources/Gui/MainScreen.cpp:227
 msgctxt "MainScreen"
 msgid "NOW LOADING"
-msgstr "CARREGANDO AGORA"
+msgstr "CARREGANDO"
 
 #: ../../Scripts/Gui/ClientUI.as:198
 msgctxt "Client"
@@ -544,7 +544,7 @@ msgstr "Ver."
 #: ../../Scripts/Gui/MainScreen.as:515 ../../Scripts/Gui/MainScreen.as:529
 msgctxt "MainScreen"
 msgid "Loc."
-msgstr "Loc."
+msgstr "Ling."
 
 #: ../../Scripts/Gui/MainScreen.as:767 ../../Scripts/Gui/MainScreen.as:787
 msgctxt "MainScreen"
@@ -597,7 +597,7 @@ msgstr "Voltar"
 #: ../../Scripts/Gui/Preferences.as:407
 msgctxt "Preferences"
 msgid "Press Key to Bind or [Escape] to Cancel..."
-msgstr "Pressione alguma Tecla para Selecionar ou [ESC] para Cancelar..."
+msgstr "Pressione alguma Tecla para Definir ou [ESC] para Cancelar..."
 
 #: ../../Scripts/Gui/Preferences.as:418
 msgctxt "Preferences"
@@ -607,7 +607,7 @@ msgstr "Espaço"
 #: ../../Scripts/Gui/Preferences.as:420
 msgctxt "Preferences"
 msgid "Unbound"
-msgstr "Não Selecionado"
+msgstr "Não Definido"
 
 #: ../../Scripts/Gui/Preferences.as:423
 msgctxt "Preferences"
@@ -647,7 +647,7 @@ msgstr "Botão do Meio do Mouse"
 #: ../../Scripts/Gui/Preferences.as:437
 msgctxt "Preferences"
 msgid "Mouse Button 4"
-msgstr "Mouse Button 4"
+msgstr "Botão do Mouse 4"
 
 #: ../../Scripts/Gui/Preferences.as:439
 msgctxt "Preferences"
@@ -933,7 +933,7 @@ msgstr "Chat de Equipe"
 #: ../../Scripts/Gui/Preferences.as:712
 msgctxt "Preferences"
 msgid "Limbo Menu"
-msgstr "Limbo Menu"
+msgstr "Menu Limbo"
 
 #: ../../Scripts/Gui/Preferences.as:713
 msgctxt "Preferences"
@@ -963,7 +963,7 @@ msgstr "Feche e reinicie o OpenSpades para acessar a janela inicial"
 #: ../../Scripts/Gui/Preferences.as:756
 msgctxt "Preferences"
 msgid "Some settings only can be changed in the startup window."
-msgstr "Algumas configurações só podem ser mudas na janela inicial."
+msgstr "Algumas configurações só podem ser mudadas na janela inicial."
 
 #: ../../Scripts/Gui/StartupScreen.as:158
 #: ../../Scripts/Gui/StartupScreen.as:159
@@ -1293,7 +1293,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1192
 msgctxt "StartupScreen"
 msgid "Dynamic Lights"
-msgstr "Luzes Dinâmicas."
+msgstr "Luzes Dinâmicas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1193
 #: ../../Scripts/Gui/StartupScreen.as:1194

--- a/Resources/Locales/pt_pt.json
+++ b/Resources/Locales/pt_pt.json
@@ -1,0 +1,4 @@
+{
+    "descriptionEnglish": "Portuguese (Portugal)",
+    "description": "Português (Portugal)"
+}

--- a/Resources/Locales/pt_pt/openspades.po
+++ b/Resources/Locales/pt_pt/openspades.po
@@ -544,7 +544,7 @@ msgstr "Ver."
 #: ../../Scripts/Gui/MainScreen.as:515 ../../Scripts/Gui/MainScreen.as:529
 msgctxt "MainScreen"
 msgid "Loc."
-msgstr "Ling."
+msgstr "Loc."
 
 #: ../../Scripts/Gui/MainScreen.as:767 ../../Scripts/Gui/MainScreen.as:787
 msgctxt "MainScreen"

--- a/Resources/Locales/pt_pt/openspades.po
+++ b/Resources/Locales/pt_pt/openspades.po
@@ -1,27 +1,28 @@
 # OpenSpades translation
-# Copyright (C) 2016 yvt
+# Copyright (C) 2014 yvt
 # This file is distributed under the same license as the OpenSpades package.
-# yvt <i@yvt.jp>, 2016.
+# yvt <i@yvt.jp>, 2014.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenSpades\n"
 "Report-Msgid-Bugs-To: i at yvt.jp\n"
 "POT-Creation-Date: 2014-02-14 15:34+0900\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2016-12-10 17:47+0000\n"
+"Language-Team: Portuguese Portugal <joaoadriano3@gmail.com>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.11\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Last-Translator: João Rodrigues <joaoadriano3@gmail.com>\n"
+"Language: pt_pt\n"
 
 #: ../../../Sources/Client/Client.cpp:586
 #: ../../../Sources/Client/Client.cpp:587
 msgctxt "Client"
 msgid "Map saved: {0}"
-msgstr ""
+msgstr "Mapa gravado: {0}"
 
 #: ../../../Sources/Client/Client.cpp:590
 #: ../../../Sources/Client/Client.cpp:596
@@ -29,263 +30,263 @@ msgstr ""
 #: ../../../Sources/Client/Client.cpp:597
 msgctxt "Client"
 msgid "Saving map failed: "
-msgstr ""
+msgstr "Falha na gravação do mapa:"
 
 #: ../../../Sources/Client/Client.cpp:628
 #: ../../../Sources/Client/Client.cpp:629
 msgctxt "Client"
 msgid "[Global] "
-msgstr ""
+msgstr "[Global]"
 
 #: ../../../Sources/Client/Client_Draw.cpp:118
 msgctxt "Client"
 msgid "Sceneshot saved: {0}"
-msgstr ""
+msgstr "Sceneshot gravado: {0}"
 
 #: ../../../Sources/Client/Client_Draw.cpp:120
 msgctxt "Client"
 msgid "Screenshot saved: {0}"
-msgstr ""
+msgstr "Captura de ecrã gravada: {0}"
 
 #: ../../../Sources/Client/Client_Draw.cpp:124
 #: ../../../Sources/Client/Client_Draw.cpp:130
 msgctxt "Client"
 msgid "Screenshot failed: "
-msgstr ""
+msgstr "Falha na captura de ecrã:"
 
 #: ../../../Sources/Client/Client_Draw.cpp:197
 msgctxt "Client"
 msgid "NOW LOADING"
-msgstr ""
+msgstr "A CARREGAR"
 
 #: ../../../Sources/Client/Client_Draw.cpp:219
 msgctxt "Client"
 msgid "Disconnecting..."
-msgstr ""
+msgstr "A desconectar..."
 
 #: ../../../Sources/Client/Client_Draw.cpp:522
 msgctxt "Client"
 msgid "Out of Block"
-msgstr ""
+msgstr "Sem Bloco"
 
 #: ../../../Sources/Client/Client_Draw.cpp:527
 msgctxt "Client"
 msgid "Out of Grenade"
-msgstr ""
+msgstr "Sem Granada"
 
 #: ../../../Sources/Client/Client_Draw.cpp:533
 msgctxt "Client"
 msgid "Reloading"
-msgstr ""
+msgstr "A recarregar"
 
 #: ../../../Sources/Client/Client_Draw.cpp:535
 #: ../../../Sources/Client/Client_Input.cpp:448
 msgctxt "Client"
 msgid "Out of Ammo"
-msgstr ""
+msgstr "Sem Munições"
 
 #: ../../../Sources/Client/Client_Draw.cpp:538
 msgctxt "Client"
 msgid "Press [{0}] to Reload"
-msgstr ""
+msgstr "Clica [{0}] para Recarregar"
 
 #: ../../../Sources/Client/Client_Draw.cpp:583
 msgctxt "Client"
 msgid "You will respawn in: {0}"
-msgstr ""
+msgstr "Renascerás em: {0}"
 
 #: ../../../Sources/Client/Client_Draw.cpp:585
 msgctxt "Client"
 msgid "Waiting for respawn"
-msgstr ""
+msgstr "A aguardar até renascer"
 
 #: ../../../Sources/Client/Client_Draw.cpp:752
 msgctxt "Client"
 msgid "Following {0}"
-msgstr ""
+msgstr "A seguir {0}"
 
 #: ../../../Sources/Client/Client_Input.cpp:436
 msgctxt "Client"
 msgid "Out of Blocks"
-msgstr ""
+msgstr "Sem Blocos"
 
 #: ../../../Sources/Client/Client_Input.cpp:460
 msgctxt "Client"
 msgid "Out of Grenades"
-msgstr ""
+msgstr "Sem Granadas"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:89
 msgctxt "Client"
 msgid "{0} captured {1}'s territory"
-msgstr ""
+msgstr "{0} capturou o território do {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:91
 msgctxt "Client"
 msgid "{0} captured an neutral territory"
-msgstr ""
+msgstr "{0} capturou um território neutro"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:99
 msgctxt "Client"
 msgid "{0} captured {1}'s Territory"
-msgstr ""
+msgstr "{0} capturou o território de {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:101
 msgctxt "Client"
 msgid "{0} captured an Neutral Territory"
-msgstr ""
+msgstr "{0} capturou um Território Neutro"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:127
 msgctxt "Client"
 msgid "{0} captured {1}'s intel"
-msgstr ""
+msgstr "{0} capturou a intel dos {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:134
 msgctxt "Client"
 msgid "{0} captured {1}'s Intel."
-msgstr ""
+msgstr "{0} capturou a Intel  dos {1}."
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:158
 msgctxt "Client"
 msgid "{0} picked up {1}'s intel"
-msgstr ""
+msgstr "{0} apanhou a Intel dos {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:165
 msgctxt "Client"
 msgid "{0} picked up {1}'s Intel."
-msgstr ""
+msgstr "{0} apanhou a Intel dos {1}."
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:183
 msgctxt "Client"
 msgid "{0} dropped {1}'s intel"
-msgstr ""
+msgstr "{0} largou a Intel dos {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:190
 msgctxt "Client"
 msgid "{0} dropped {1}'s Intel"
-msgstr ""
+msgstr "{0} largou a Intel dos {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:237
 #: ../../../Sources/Client/Client_NetHandler.cpp:243
 msgctxt "Client"
 msgid "Player {0} has left"
-msgstr ""
+msgstr "Jogador {0} saiu"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:257
 #: ../../../Sources/Client/Client_NetHandler.cpp:264
 msgctxt "Client"
 msgid "{0} joined {1} team"
-msgstr ""
+msgstr "{0} juntou-se à equipa {1}"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:294
 msgctxt "Client"
 msgid "{0} wins!"
-msgstr ""
+msgstr "{0} ganharam!"
 
 #: ../../../Sources/Client/Client_NetHandler.cpp:298
 msgctxt "Client"
 msgid "{0} Wins!"
-msgstr ""
+msgstr "{0} Ganharam!"
 
 #: ../../../Sources/Client/Client_Update.cpp:457
 msgctxt "Client"
 msgid "{0} block"
 msgid_plural "{0} blocks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{0} bloco"
+msgstr[1] "{0} blocos"
 
 #: ../../../Sources/Client/Client_Update.cpp:464
 msgctxt "Client"
 msgid "-- blocks"
-msgstr ""
+msgstr "-- blocos"
 
 #: ../../../Sources/Client/Client_Update.cpp:851
 msgctxt "Client"
 msgid "You have killed {0}"
-msgstr ""
+msgstr "Mataste o {0}"
 
 #: ../../../Sources/Client/Client_Update.cpp:853
 msgctxt "Client"
 msgid "You were killed by {0}"
-msgstr ""
+msgstr "Foste morto pelo {0}"
 
 #: ../../../Sources/Client/Client_Update.cpp:1166
 msgctxt "Client"
 msgid "Insufficient blocks."
-msgstr ""
+msgstr "Blocos insuficientes."
 
 #: ../../../Sources/Client/Client_Update.cpp:1169
 msgctxt "Client"
 msgid "You cannot place a block there."
-msgstr ""
+msgstr "Não podes colocar um bloco ali."
 
 #: ../../../Sources/Client/LimboView.cpp:67
 msgctxt "Client"
 msgid "Rifle"
-msgstr ""
+msgstr "Rifle"
 
 #: ../../../Sources/Client/LimboView.cpp:70
 msgctxt "Client"
 msgid "SMG"
-msgstr ""
+msgstr "SMG"
 
 #: ../../../Sources/Client/LimboView.cpp:73
 msgctxt "Client"
 msgid "Shotgun"
-msgstr ""
+msgstr "Caçadeira"
 
 #: ../../../Sources/Client/LimboView.cpp:77
 msgctxt "Client"
 msgid "Spawn"
-msgstr ""
+msgstr "Nascer"
 
 #: ../../../Sources/Client/LimboView.cpp:181
 msgctxt "Client"
 msgid "Select Team:"
-msgstr ""
+msgstr "Selecciona a Equipa:"
 
 #: ../../../Sources/Client/LimboView.cpp:189
 msgctxt "Client"
 msgid "Select Weapon:"
-msgstr ""
+msgstr "Selecciona a Arma"
 
 #: ../../../Sources/Client/NetClient.cpp:376
 msgctxt "NetClient"
 msgid "Connecting to the server"
-msgstr ""
+msgstr "A conectar ao servidor"
 
 #: ../../../Sources/Client/NetClient.cpp:390
 msgctxt "NetClient"
 msgid "Not connected"
-msgstr ""
+msgstr "Não conectado"
 
 #: ../../../Sources/Client/NetClient.cpp:459
 msgctxt "NetClient"
 msgid "Awaiting for state"
-msgstr ""
+msgstr "A aguardar pelo estado"
 
 #: ../../../Sources/Client/NetClient.cpp:469
 #: ../../../Sources/Client/NetClient.cpp:1235
 msgctxt "NetClient"
 msgid "Loading snapshot"
-msgstr ""
+msgstr "A carregar snapshot"
 
 #: ../../../Sources/Client/NetClient.cpp:484
 msgctxt "NetClient"
 msgid "Loading snapshot ({0}/{1})"
-msgstr ""
+msgstr "A carregar snapshot ({0}/{1})"
 
 #: ../../../Sources/Client/NetClient.cpp:489
 #: ../../../Sources/Client/NetClient.cpp:523
 msgctxt "NetClient"
 msgid "Connected"
-msgstr ""
+msgstr "Conectado"
 
 #: ../../../Sources/Client/NetClient.cpp:501
 #: ../../../Sources/Client/NetClient.cpp:536
 #: ../../../Sources/Client/NetClient.cpp:588
 msgctxt "NetClient"
 msgid "Still loading..."
-msgstr ""
+msgstr "Ainda a carregar..."
 
 #: ../../../Sources/Client/NetClient.cpp:504
 #: ../../../Sources/Client/NetClient.cpp:510
@@ -295,55 +296,55 @@ msgstr ""
 #: ../../../Sources/Client/NetClient.cpp:597
 msgctxt "NetClient"
 msgid "Error"
-msgstr ""
+msgstr "Erro"
 
 #: ../../../Sources/Client/NetClient.cpp:663
 msgctxt "NetClient"
 msgid "You are banned from this server."
-msgstr ""
+msgstr "Foste banido deste servidor."
 
 #: ../../../Sources/Client/NetClient.cpp:668
 #: ../../../Sources/Client/NetClient.cpp:671
 msgctxt "NetClient"
 msgid "You were kicked from this server."
-msgstr ""
+msgstr "Foste expulso deste servidor."
 
 #: ../../../Sources/Client/NetClient.cpp:669
 msgctxt "NetClient"
 msgid "Incompatible client protocol version."
-msgstr ""
+msgstr "Versão do protocolo do client incompatível."
 
 #: ../../../Sources/Client/NetClient.cpp:670
 msgctxt "NetClient"
 msgid "Server full"
-msgstr ""
+msgstr "Servidor cheio"
 
 #: ../../../Sources/Client/NetClient.cpp:672
 msgctxt "NetClient"
 msgid "Unknown Reason"
-msgstr ""
+msgstr "Motivo desconhecido"
 
 #: ../../../Sources/Client/ScoreboardView.cpp:330
 msgctxt "Client"
 msgid "Spectator{1}"
 msgid_plural "Spectators{1}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Espectador{1}"
+msgstr[1] "Espectadores{1}"
 
 #: ../../../Sources/Client/TCProgressView.cpp:150
 msgctxt "Client"
 msgid "Neutral Territory"
-msgstr ""
+msgstr "Território Neutro"
 
 #: ../../../Sources/Client/TCProgressView.cpp:153
 msgctxt "Client"
 msgid "{0}'s Territory"
-msgstr ""
+msgstr "Território dos {0}"
 
 #: ../../../Sources/Gui/Main.cpp:622 ../../../Sources/Gui/Main.cpp:634
 msgctxt "Main"
 msgid "Localization System Loaded"
-msgstr ""
+msgstr "Sistema de Linguagem carregado"
 
 #: ../../../Sources/Gui/Main.cpp:680 ../../../Sources/Gui/Runner.cpp:58
 #: ../../../Sources/Gui/Main.cpp:692
@@ -355,190 +356,195 @@ msgid ""
 "\n"
 "See SystemMessages.log for more details."
 msgstr ""
+"Um erro crítico fez com que o OpenSpades deixásse de funcionar:\n"
+"\n"
+"{0}\n"
+"\n"
+"Veja o SystemMessages.log para mais detalhes."
 
 #: ../../../Sources/Gui/Main.cpp:688 ../../../Sources/Gui/Runner.cpp:64
 #: ../../../Sources/Gui/Main.cpp:700
 msgctxt "Main"
 msgid "OpenSpades Fatal Error"
-msgstr ""
+msgstr "Erro Crítico do OpenSpades"
 
 #: ../../../Sources/Gui/MainScreen.cpp:227
 msgctxt "MainScreen"
 msgid "NOW LOADING"
-msgstr ""
+msgstr "A CARREGAR"
 
 #: ../../Scripts/Gui/ClientUI.as:198
 msgctxt "Client"
 msgid "Back to Game"
-msgstr ""
+msgstr "Voltar ao Jogo"
 
 #: ../../Scripts/Gui/ClientUI.as:205
 msgctxt "Client"
 msgid "Chat Log"
-msgstr ""
+msgstr "Histórico do Chat"
 
 #: ../../Scripts/Gui/ClientUI.as:212
 msgctxt "Client"
 msgid "Setup"
-msgstr ""
+msgstr "Definições"
 
 #: ../../Scripts/Gui/ClientUI.as:219
 msgctxt "Client"
 msgid "Disconnect"
-msgstr ""
+msgstr "Desconectar"
 
 #: ../../Scripts/Gui/ClientUI.as:484
 msgctxt "Client"
 msgid "Say"
-msgstr ""
+msgstr "Falar"
 
 #: ../../Scripts/Gui/ClientUI.as:492
 msgctxt "Client"
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: ../../Scripts/Gui/ClientUI.as:500
 msgctxt "Client"
 msgid "Chat Text"
-msgstr ""
+msgstr "Texto do Chat"
 
 #: ../../Scripts/Gui/ClientUI.as:508
 msgctxt "Client"
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 #: ../../Scripts/Gui/ClientUI.as:517
 msgctxt "Client"
 msgid "Team"
-msgstr ""
+msgstr "Equipa"
 
 #: ../../Scripts/Gui/ClientUI.as:661
 msgctxt "Client"
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 #: ../../Scripts/Gui/ClientUI.as:671
 msgctxt "Client"
 msgid "Say Global"
-msgstr ""
+msgstr "Falar Global"
 
 #: ../../Scripts/Gui/ClientUI.as:682
 msgctxt "Client"
 msgid "Say Team"
-msgstr ""
+msgstr "Falar Equipa"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:58
 msgctxt "CreateProfileScreen"
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:70
 msgctxt "CreateProfileScreen"
 msgid "Decide later"
-msgstr ""
+msgstr "Decidir mais tarde"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:80
 msgctxt "CreateProfileScreen"
 msgid "Welcome to OpenSpades"
-msgstr ""
+msgstr "Bem-vindo ao OpenSpades"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:88
 msgctxt "CreateProfileScreen"
 msgid "Choose a player name:"
-msgstr ""
+msgstr "Escolhe um nome de jogador:"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:96
 msgctxt "CreateProfileScreen"
 msgid "Player name"
-msgstr ""
+msgstr "Nome do Jogador"
 
 #: ../../Scripts/Gui/CreateProfileScreen.as:104
 msgctxt "CreateProfileScreen"
 msgid "You can change it later in the Setup dialog."
-msgstr ""
+msgstr "Podes alterá-lo mais tarde nas Definições."
 
 #: ../../Scripts/Gui/MainScreen.as:362 ../../Scripts/Gui/MainScreen.as:376
 msgctxt "MainScreen"
 msgid "Connect"
-msgstr ""
+msgstr "Conectar"
 
 #: ../../Scripts/Gui/MainScreen.as:370 ../../Scripts/Gui/MainScreen.as:384
 msgctxt "MainScreen"
 msgid "Quick Connect"
-msgstr ""
+msgstr "Conexão Rápida"
 
 #: ../../Scripts/Gui/MainScreen.as:379 ../../Scripts/Gui/MainScreen.as:433
 #: ../../Scripts/Gui/MainScreen.as:393 ../../Scripts/Gui/MainScreen.as:447
 msgctxt "MainScreen"
 msgid "0.75"
-msgstr ""
+msgstr "0.75"
 
 #: ../../Scripts/Gui/MainScreen.as:389 ../../Scripts/Gui/MainScreen.as:442
 #: ../../Scripts/Gui/MainScreen.as:403 ../../Scripts/Gui/MainScreen.as:456
 msgctxt "MainScreen"
 msgid "0.76"
-msgstr ""
+msgstr "0.76"
 
 #: ../../Scripts/Gui/MainScreen.as:397 ../../Scripts/Gui/MainScreen.as:411
 msgctxt "MainScreen"
 msgid "Quit"
-msgstr ""
+msgstr "Sair"
 
 #: ../../Scripts/Gui/MainScreen.as:404 ../../Scripts/Gui/MainScreen.as:418
 msgctxt "MainScreen"
 msgid "Credits"
-msgstr ""
+msgstr "Crédito"
 
 #: ../../Scripts/Gui/MainScreen.as:411 ../../Scripts/Gui/MainScreen.as:425
 msgctxt "MainScreen"
 msgid "Setup"
-msgstr ""
+msgstr "Definições"
 
 #: ../../Scripts/Gui/MainScreen.as:424 ../../Scripts/Gui/MainScreen.as:468
 #: ../../Scripts/Gui/MainScreen.as:438 ../../Scripts/Gui/MainScreen.as:482
 msgctxt "MainScreen"
 msgid "Filter"
-msgstr ""
+msgstr "Filtrar"
 
 #: ../../Scripts/Gui/MainScreen.as:451 ../../Scripts/Gui/MainScreen.as:465
 msgctxt "MainScreen"
 msgid "Empty"
-msgstr ""
+msgstr "Vazio"
 
 #: ../../Scripts/Gui/MainScreen.as:460 ../../Scripts/Gui/MainScreen.as:474
 msgctxt "MainScreen"
 msgid "Not Full"
-msgstr ""
+msgstr "Livre"
 
 #: ../../Scripts/Gui/MainScreen.as:480 ../../Scripts/Gui/MainScreen.as:494
 msgctxt "MainScreen"
 msgid "Server Name"
-msgstr ""
+msgstr "Nome do Servidor"
 
 #: ../../Scripts/Gui/MainScreen.as:487 ../../Scripts/Gui/MainScreen.as:501
 msgctxt "MainScreen"
 msgid "Players"
-msgstr ""
+msgstr "Jogadores"
 
 #: ../../Scripts/Gui/MainScreen.as:494 ../../Scripts/Gui/MainScreen.as:508
 msgctxt "MainScreen"
 msgid "Map Name"
-msgstr ""
+msgstr "Nome do Mapa"
 
 #: ../../Scripts/Gui/MainScreen.as:501 ../../Scripts/Gui/MainScreen.as:515
 msgctxt "MainScreen"
 msgid "Game Mode"
-msgstr ""
+msgstr "Modo de Jogo"
 
 #: ../../Scripts/Gui/MainScreen.as:508 ../../Scripts/Gui/MainScreen.as:522
 msgctxt "MainScreen"
 msgid "Ver."
-msgstr ""
+msgstr "Ver."
 
 #: ../../Scripts/Gui/MainScreen.as:515 ../../Scripts/Gui/MainScreen.as:529
 msgctxt "MainScreen"
 msgid "Loc."
-msgstr ""
+msgstr "Ling."
 
 #: ../../Scripts/Gui/MainScreen.as:767 ../../Scripts/Gui/MainScreen.as:787
 msgctxt "MainScreen"
@@ -547,450 +553,453 @@ msgid ""
 "\n"
 "{0}"
 msgstr ""
+"Foste desconectado do servidor pelo seguinte motivo:\n"
+"\n"
+"{0}"
 
 #: ../../Scripts/Gui/MainScreen.as:787 ../../Scripts/Gui/MainScreen.as:807
 msgctxt "MainScreen"
 msgid "Loading..."
-msgstr ""
+msgstr "A carregar..."
 
 #: ../../Scripts/Gui/MainScreen.as:805 ../../Scripts/Gui/MainScreen.as:825
 msgctxt "MainScreen"
 msgid "Failed to fetch the server list."
-msgstr ""
+msgstr "Falha ao obter a lista de servidores."
 
 #: ../../Scripts/Gui/MessageBox.as:53 ../../Scripts/Gui/MessageBox.as:130
 #: ../../Scripts/Gui/MessageBox.as:144
 msgctxt "MessageBox"
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../../Scripts/Gui/Preferences.as:60
 msgctxt "Preferences"
 msgid "Game Options"
-msgstr ""
+msgstr "Definições do Jogo"
 
 #: ../../Scripts/Gui/Preferences.as:61
 msgctxt "Preferences"
 msgid "Controls"
-msgstr ""
+msgstr "Controlos"
 
 #: ../../Scripts/Gui/Preferences.as:62 ../../Scripts/Gui/Preferences.as:661
 #: ../../Scripts/Gui/Preferences.as:706
 msgctxt "Preferences"
 msgid "Misc"
-msgstr ""
+msgstr "Outras"
 
 #: ../../Scripts/Gui/Preferences.as:66
 msgctxt "Preferences"
 msgid "Back"
-msgstr ""
+msgstr "Voltar"
 
 #: ../../Scripts/Gui/Preferences.as:407
 msgctxt "Preferences"
 msgid "Press Key to Bind or [Escape] to Cancel..."
-msgstr ""
+msgstr "Pressiona uma tecla para seleccionar ou [ESC] para cancelar..."
 
 #: ../../Scripts/Gui/Preferences.as:418
 msgctxt "Preferences"
 msgid "Space"
-msgstr ""
+msgstr "Espaço"
 
 #: ../../Scripts/Gui/Preferences.as:420
 msgctxt "Preferences"
 msgid "Unbound"
-msgstr ""
+msgstr "Não Definido"
 
 #: ../../Scripts/Gui/Preferences.as:423
 msgctxt "Preferences"
 msgid "Shift"
-msgstr ""
+msgstr "Shift"
 
 #: ../../Scripts/Gui/Preferences.as:425
 msgctxt "Preferences"
 msgid "Control"
-msgstr ""
+msgstr "Control"
 
 #: ../../Scripts/Gui/Preferences.as:427
 msgctxt "Preferences"
 msgid "Meta"
-msgstr ""
+msgstr "Meta"
 
 #: ../../Scripts/Gui/Preferences.as:429
 msgctxt "Preferences"
 msgid "Alt"
-msgstr ""
+msgstr "Alt"
 
 #: ../../Scripts/Gui/Preferences.as:431
 msgctxt "Preferences"
 msgid "Left Mouse Button"
-msgstr ""
+msgstr "Botão Esquerdo do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:433
 msgctxt "Preferences"
 msgid "Right Mouse Button"
-msgstr ""
+msgstr "Botão Direito do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:435
 msgctxt "Preferences"
 msgid "Middle Mouse Button"
-msgstr ""
+msgstr "Botão do Meio do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:437
 msgctxt "Preferences"
 msgid "Mouse Button 4"
-msgstr ""
+msgstr "Botão 4 do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:439
 msgctxt "Preferences"
 msgid "Mouse Button 5"
-msgstr ""
+msgstr "Botão 5 do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:611 ../../Scripts/Gui/Preferences.as:617
 msgctxt "Preferences"
 msgid "ON"
-msgstr ""
+msgstr "ON"
 
 #: ../../Scripts/Gui/Preferences.as:611 ../../Scripts/Gui/Preferences.as:617
 #: ../../Scripts/Gui/Preferences.as:646 ../../Scripts/Gui/Preferences.as:649
 msgctxt "Preferences"
 msgid "OFF"
-msgstr ""
+msgstr "OFF"
 
 #: ../../Scripts/Gui/Preferences.as:617
 msgctxt "Preferences"
 msgid "REVERSED"
-msgstr ""
+msgstr "INVERSO"
 
 #: ../../Scripts/Gui/Preferences.as:635
 msgctxt "Preferences"
 msgid "Player Information"
-msgstr ""
+msgstr "Informações do Jogador"
 
 #: ../../Scripts/Gui/Preferences.as:636
 msgctxt "Preferences"
 msgid "Player Name"
-msgstr ""
+msgstr "Nome do Jogador"
 
 #: ../../Scripts/Gui/Preferences.as:640
 msgctxt "Preferences"
 msgid "Effects"
-msgstr ""
+msgstr "Efeitos"
 
 #: ../../Scripts/Gui/Preferences.as:641
 msgctxt "Preferences"
 msgid "Blood"
-msgstr ""
+msgstr "Sangue"
 
 #: ../../Scripts/Gui/Preferences.as:642
 msgctxt "Preferences"
 msgid "Ejecting Brass"
-msgstr ""
+msgstr "Ejetar Cápsulas"
 
 #: ../../Scripts/Gui/Preferences.as:643
 msgctxt "Preferences"
 msgid "Ragdoll"
-msgstr ""
+msgstr "Ragdolls"
 
 #: ../../Scripts/Gui/Preferences.as:644
 msgctxt "Preferences"
 msgid "Animations"
-msgstr ""
+msgstr "Animações"
 
 #: ../../Scripts/Gui/Preferences.as:645
 msgctxt "Preferences"
 msgid "Camera Shake"
-msgstr ""
+msgstr "Tremor da Câmara"
 
 #: ../../Scripts/Gui/Preferences.as:646
 msgctxt "Preferences"
 msgid "MORE"
-msgstr ""
+msgstr "MUITAS"
 
 #: ../../Scripts/Gui/Preferences.as:646 ../../Scripts/Gui/Preferences.as:649
 msgctxt "Preferences"
 msgid "NORMAL"
-msgstr ""
+msgstr "NORMAL"
 
 #: ../../Scripts/Gui/Preferences.as:648
 msgctxt "Preferences"
 msgid "Particles"
-msgstr ""
+msgstr "Partículas"
 
 #: ../../Scripts/Gui/Preferences.as:649
 msgctxt "Preferences"
 msgid "LESS"
-msgstr ""
+msgstr "MENOS"
 
 #: ../../Scripts/Gui/Preferences.as:652
 msgctxt "Preferences"
 msgid "Feedbacks"
-msgstr ""
+msgstr "Alertas"
 
 #: ../../Scripts/Gui/Preferences.as:653
 msgctxt "Preferences"
 msgid "Chat Notify Sounds"
-msgstr ""
+msgstr "Sons de Notificação do Chat"
 
 #: ../../Scripts/Gui/Preferences.as:654
 msgctxt "Preferences"
 msgid "Hit Indicator"
-msgstr ""
+msgstr "Indicador de Acertos"
 
 #: ../../Scripts/Gui/Preferences.as:655
 msgctxt "Preferences"
 msgid "Show Alerts"
-msgstr ""
+msgstr "Mostrar Alertas"
 
 #: ../../Scripts/Gui/Preferences.as:657
 msgctxt "Preferences"
 msgid "AoS 0.75/0.76 Compatibility"
-msgstr ""
+msgstr "Compatibilidade entre AoS 0.75/0.76"
 
 #: ../../Scripts/Gui/Preferences.as:658
 msgctxt "Preferences"
 msgid "Allow Unicode"
-msgstr ""
+msgstr "Permitir Unicode"
 
 #: ../../Scripts/Gui/Preferences.as:659
 msgctxt "Preferences"
 msgid "Server Alert"
-msgstr ""
+msgstr "Alerta do Servidor"
 
 #: ../../Scripts/Gui/Preferences.as:662
 msgctxt "Preferences"
 msgid "Field of View"
-msgstr ""
+msgstr "Campo de Visão"
 
 #: ../../Scripts/Gui/Preferences.as:664
 msgctxt "Preferences"
 msgid "Minimap size"
-msgstr ""
+msgstr "Tamanho do Minimapa"
 
 #: ../../Scripts/Gui/Preferences.as:666
 msgctxt "Preferences"
 msgid "Show Statistics"
-msgstr ""
+msgstr "Exibir Estatísticas"
 
 #: ../../Scripts/Gui/Preferences.as:676
 msgctxt "Preferences"
 msgid "Weapons/Tools"
-msgstr ""
+msgstr "Armas/Ferramentas"
 
 #: ../../Scripts/Gui/Preferences.as:677
 msgctxt "Preferences"
 msgid "Attack"
-msgstr ""
+msgstr "Ataque"
 
 #: ../../Scripts/Gui/Preferences.as:678
 msgctxt "Preferences"
 msgid "Alt. Attack"
-msgstr ""
+msgstr "Ataque alt."
 
 #: ../../Scripts/Gui/Preferences.as:679
 msgctxt "Preferences"
 msgid "Hold Aim Down Sight"
-msgstr ""
+msgstr "Segurar a Mira"
 
 #: ../../Scripts/Gui/Preferences.as:680
 msgctxt "Preferences"
 msgid "Mouse Sensitivity"
-msgstr ""
+msgstr "Sensibilidade do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:682
 msgctxt "Preferences"
 msgid "ADS Mouse Sens. Scale"
-msgstr ""
+msgstr "Sens. do Rato a fazer Mira"
 
 #: ../../Scripts/Gui/Preferences.as:684
 msgctxt "Preferences"
 msgid "Exponential Power"
-msgstr ""
+msgstr "Força Exponencial"
 
 #: ../../Scripts/Gui/Preferences.as:686
 msgctxt "Preferences"
 msgid "Invert Y-axis Mouse Input"
-msgstr ""
+msgstr "inverter o Eixo Y do Rato"
 
 #: ../../Scripts/Gui/Preferences.as:687
 msgctxt "Preferences"
 msgid "Reload"
-msgstr ""
+msgstr "Recarregar"
 
 #: ../../Scripts/Gui/Preferences.as:688
 msgctxt "Preferences"
 msgid "Capture Color"
-msgstr ""
+msgstr "Capturar Cor"
 
 #: ../../Scripts/Gui/Preferences.as:689
 msgctxt "Preferences"
 msgid "Equip Spade"
-msgstr ""
+msgstr "Equipar a Pá"
 
 #: ../../Scripts/Gui/Preferences.as:690
 msgctxt "Preferences"
 msgid "Equip Block"
-msgstr ""
+msgstr "Equipar Bloco"
 
 #: ../../Scripts/Gui/Preferences.as:691
 msgctxt "Preferences"
 msgid "Equip Weapon"
-msgstr ""
+msgstr "Equipar Arma"
 
 #: ../../Scripts/Gui/Preferences.as:692
 msgctxt "Preferences"
 msgid "Equip Grenade"
-msgstr ""
+msgstr "Equipar Granada"
 
 #: ../../Scripts/Gui/Preferences.as:693
 msgctxt "Preferences"
 msgid "Last Used Tool"
-msgstr ""
+msgstr "Última ferramenta usada"
 
 #: ../../Scripts/Gui/Preferences.as:694
 msgctxt "Preferences"
 msgid "Switch Tools by Wheel"
-msgstr ""
+msgstr "Trocar Ferramentas com a Roda"
 
 #: ../../Scripts/Gui/Preferences.as:696
 msgctxt "Preferences"
 msgid "Movement"
-msgstr ""
+msgstr "Movimento"
 
 #: ../../Scripts/Gui/Preferences.as:697
 msgctxt "Preferences"
 msgid "Walk Forward"
-msgstr ""
+msgstr "Andar para Frente"
 
 #: ../../Scripts/Gui/Preferences.as:698
 msgctxt "Preferences"
 msgid "Backpedal"
-msgstr ""
+msgstr "Recuar"
 
 #: ../../Scripts/Gui/Preferences.as:699
 msgctxt "Preferences"
 msgid "Move Left"
-msgstr ""
+msgstr "Andar para Esquerda"
 
 #: ../../Scripts/Gui/Preferences.as:700
 msgctxt "Preferences"
 msgid "Move Right"
-msgstr ""
+msgstr "Andar para Direita"
 
 #: ../../Scripts/Gui/Preferences.as:701
 msgctxt "Preferences"
 msgid "Crouch"
-msgstr ""
+msgstr "Agachar"
 
 #: ../../Scripts/Gui/Preferences.as:702
 msgctxt "Preferences"
 msgid "Sneak"
-msgstr ""
+msgstr "Andar Furtivamente"
 
 #: ../../Scripts/Gui/Preferences.as:703
 msgctxt "Preferences"
 msgid "Jump"
-msgstr ""
+msgstr "Saltar"
 
 #: ../../Scripts/Gui/Preferences.as:704
 msgctxt "Preferences"
 msgid "Sprint"
-msgstr ""
+msgstr "Correr"
 
 #: ../../Scripts/Gui/Preferences.as:707
 msgctxt "Preferences"
 msgid "Minimap Scale"
-msgstr ""
+msgstr "Escala do Minimapa"
 
 #: ../../Scripts/Gui/Preferences.as:708
 msgctxt "Preferences"
 msgid "Toggle Map"
-msgstr ""
+msgstr "Alternar entre Mapa/Minimapa"
 
 #: ../../Scripts/Gui/Preferences.as:709
 msgctxt "Preferences"
 msgid "Flashlight"
-msgstr ""
+msgstr "Lanterna"
 
 #: ../../Scripts/Gui/Preferences.as:710
 msgctxt "Preferences"
 msgid "Global Chat"
-msgstr ""
+msgstr "Chat Global"
 
 #: ../../Scripts/Gui/Preferences.as:711
 msgctxt "Preferences"
 msgid "Team Chat"
-msgstr ""
+msgstr "Chat de Equipa"
 
 #: ../../Scripts/Gui/Preferences.as:712
 msgctxt "Preferences"
 msgid "Limbo Menu"
-msgstr ""
+msgstr "Menu do Limbo"
 
 #: ../../Scripts/Gui/Preferences.as:713
 msgctxt "Preferences"
 msgid "Save Map"
-msgstr ""
+msgstr "Gravar Mapa"
 
 #: ../../Scripts/Gui/Preferences.as:714
 msgctxt "Preferences"
 msgid "Save Sceneshot"
-msgstr ""
+msgstr "Guardar Sceneshot"
 
 #: ../../Scripts/Gui/Preferences.as:715
 msgctxt "Preferences"
 msgid "Save Screenshot"
-msgstr ""
+msgstr "Guardar Captura de Ecrã"
 
 #: ../../Scripts/Gui/Preferences.as:734
 msgctxt "Preferences"
 msgid "Enable Startup Window"
-msgstr ""
+msgstr "Ativar Janela Inicial"
 
 #: ../../Scripts/Gui/Preferences.as:755
 msgctxt "Preferences"
 msgid "Quit and restart OpenSpades to access the startup window."
-msgstr ""
+msgstr "Saia e reinicie o OpenSpades para aceder à janela inicial"
 
 #: ../../Scripts/Gui/Preferences.as:756
 msgctxt "Preferences"
 msgid "Some settings only can be changed in the startup window."
-msgstr ""
+msgstr "Algumas definições só podem ser alteradas na janela inicial."
 
 #: ../../Scripts/Gui/StartupScreen.as:158
 #: ../../Scripts/Gui/StartupScreen.as:159
 msgctxt "StartupScreen"
 msgid "Start"
-msgstr ""
+msgstr "Iniciar"
 
 #: ../../Scripts/Gui/StartupScreen.as:165
 #: ../../Scripts/Gui/StartupScreen.as:166
 msgctxt "StartupScreen"
 msgid "Skip this screen next time"
-msgstr ""
+msgstr "Saltar este ecrã da próxima vez"
 
 #: ../../Scripts/Gui/StartupScreen.as:203
 #: ../../Scripts/Gui/StartupScreen.as:204
 msgctxt "StartupScreen"
 msgid "Graphics"
-msgstr ""
+msgstr "Gráficos"
 
 #: ../../Scripts/Gui/StartupScreen.as:204
 #: ../../Scripts/Gui/StartupScreen.as:205
 msgctxt "StartupScreen"
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 #: ../../Scripts/Gui/StartupScreen.as:205
 #: ../../Scripts/Gui/StartupScreen.as:206
 msgctxt "StartupScreen"
 msgid "Generic"
-msgstr ""
+msgstr "Genérico"
 
 #: ../../Scripts/Gui/StartupScreen.as:206
 #: ../../Scripts/Gui/StartupScreen.as:207
 msgctxt "StartupScreen"
 msgid "System Info"
-msgstr ""
+msgstr "Informações do Sistema"
 
 #: ../../Scripts/Gui/StartupScreen.as:207
 #: ../../Scripts/Gui/StartupScreen.as:208
@@ -999,37 +1008,37 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1657
 msgctxt "StartupScreen"
 msgid "Advanced"
-msgstr ""
+msgstr "Avançado"
 
 #: ../../Scripts/Gui/StartupScreen.as:835
 #: ../../Scripts/Gui/StartupScreen.as:836
 msgctxt "StartupScreen"
 msgid "Custom"
-msgstr ""
+msgstr "Customizado"
 
 #: ../../Scripts/Gui/StartupScreen.as:961
 #: ../../Scripts/Gui/StartupScreen.as:962
 msgctxt "StartupScreen"
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 #: ../../Scripts/Gui/StartupScreen.as:1067
 #: ../../Scripts/Gui/StartupScreen.as:1068
 msgctxt "StartupScreen"
 msgid "Graphics Settings"
-msgstr ""
+msgstr "Configurações Gráficas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1072
 #: ../../Scripts/Gui/StartupScreen.as:1073
 msgctxt "StartupScreen"
 msgid "Resolution"
-msgstr ""
+msgstr "Resolução"
 
 #: ../../Scripts/Gui/StartupScreen.as:1082
 #: ../../Scripts/Gui/StartupScreen.as:1083
 msgctxt "StartupScreen"
 msgid "Fullscreen Mode"
-msgstr ""
+msgstr "Modo de Ecrã Inteiro"
 
 #: ../../Scripts/Gui/StartupScreen.as:1085
 #: ../../Scripts/Gui/StartupScreen.as:1086
@@ -1038,6 +1047,8 @@ msgid ""
 "By running in fullscreen mode OpenSpades occupies the screen, making it "
 "easier for you to concentrate on playing the game."
 msgstr ""
+"Por executar o OpenSpade em modo de ecrã inteiro ocupa o ecrã todo, sendo "
+"mais fácil para ti de te concentrares no jogo."
 
 #: ../../Scripts/Gui/StartupScreen.as:1092
 #: ../../Scripts/Gui/StartupScreen.as:1470
@@ -1045,13 +1056,13 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1471
 msgctxt "StartupScreen"
 msgid "Backend"
-msgstr ""
+msgstr "Backend"
 
 #: ../../Scripts/Gui/StartupScreen.as:1095
 #: ../../Scripts/Gui/StartupScreen.as:1096
 msgctxt "StartupScreen"
 msgid "OpenGL"
-msgstr ""
+msgstr "OpenGL"
 
 #: ../../Scripts/Gui/StartupScreen.as:1099
 #: ../../Scripts/Gui/StartupScreen.as:1100
@@ -1060,12 +1071,14 @@ msgid ""
 "OpenGL renderer uses your computer's graphics accelerator to generate the "
 "game screen."
 msgstr ""
+"A renderização OpenGL usa a aceleração de gráficos do teu computador para "
+"gerar os gráficos."
 
 #: ../../Scripts/Gui/StartupScreen.as:1107
 #: ../../Scripts/Gui/StartupScreen.as:1108
 msgctxt "StartupScreen"
 msgid "Software"
-msgstr ""
+msgstr "Software"
 
 #: ../../Scripts/Gui/StartupScreen.as:1111
 #: ../../Scripts/Gui/StartupScreen.as:1112
@@ -1075,12 +1088,15 @@ msgid ""
 "performance might be inferior to OpenGL renderer, but it works even with an "
 "unsupported GPU."
 msgstr ""
+"A renderização Software usa o teu CPU para gerar os gráficos. A sua "
+"qualidade e desempenho podem ser inferiores ao OpenGL, mas podem funcionar "
+"melhor em GPUs não suportados."
 
 #: ../../Scripts/Gui/StartupScreen.as:1125
 #: ../../Scripts/Gui/StartupScreen.as:1126
 msgctxt "StartupScreen"
 msgid ""
-"Antialias: Enables a technique to improve the appearance of high-contrast "
+"Antialias:Enables a technique to improve the appearance of high-constrast "
 "edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution "
@@ -1089,12 +1105,20 @@ msgid ""
 "FXAA: Performs antialiasing by smoothing artifacts out as a post-process.|"
 "Off|MSAA 2x|4x|FXAA"
 msgstr ""
+"Antialias: Ativa uma técnica para melhorar a aparência dos cantos de alto-"
+"contraste.\n"
+"\n"
+"MSAA: Executa antialiasing gerando uma imagem de alta resolução "
+"intermediária. Parece melhor, mas não combina com algumas definições.\n"
+"\n"
+"FXAA: Executa antialiasing por suavizar artefactos como um pós-"
+"processamento.|Off|MSAA 2x|4x|FXAA"
 
 #: ../../Scripts/Gui/StartupScreen.as:1132
 #: ../../Scripts/Gui/StartupScreen.as:1133
 msgctxt "StartupScreen"
 msgid "Global Illumination"
-msgstr ""
+msgstr "Iluminação Global"
 
 #: ../../Scripts/Gui/StartupScreen.as:1134
 #: ../../Scripts/Gui/StartupScreen.as:1135
@@ -1103,12 +1127,14 @@ msgid ""
 "Enables a physically based simulation of light path for more realistic "
 "lighting."
 msgstr ""
+"Ativa uma simulação física baseada no caminho de luz para uma iluminação "
+"mais realista."
 
 #: ../../Scripts/Gui/StartupScreen.as:1137
 #: ../../Scripts/Gui/StartupScreen.as:1138
 msgctxt "StartupScreen"
 msgid "Linear HDR Rendering"
-msgstr ""
+msgstr "Renderização Linear HDR"
 
 #: ../../Scripts/Gui/StartupScreen.as:1139
 #: ../../Scripts/Gui/StartupScreen.as:1140
@@ -1119,90 +1145,94 @@ msgid ""
 "is in linear correspondence with actual energy, that is, physically accurate "
 "blending can be achieved."
 msgstr ""
+"Usa uma representação numérica que permite uma faixa dinâmica maior durante "
+"o processo de renderização. Adicionalmente, permite o cálculo de cor cujo "
+"valor é em correspondência linear com a energia atual, isto é, misturas "
+"físicas podem ser feitas."
 
 #: ../../Scripts/Gui/StartupScreen.as:1146
 #: ../../Scripts/Gui/StartupScreen.as:1147
 msgctxt "StartupScreen"
 msgid "Camera Blur"
-msgstr ""
+msgstr "Desfoque da Câmara"
 
 #: ../../Scripts/Gui/StartupScreen.as:1147
 #: ../../Scripts/Gui/StartupScreen.as:1148
 msgctxt "StartupScreen"
 msgid "Blurs the screen when you turn quickly."
-msgstr ""
+msgstr "Causa um desfoque quando te moves rapidamente."
 
 #: ../../Scripts/Gui/StartupScreen.as:1149
 #: ../../Scripts/Gui/StartupScreen.as:1150
 msgctxt "StartupScreen"
 msgid "Lens Effect"
-msgstr ""
+msgstr "Efeito de Lentes"
 
 #: ../../Scripts/Gui/StartupScreen.as:1150
 #: ../../Scripts/Gui/StartupScreen.as:1151
 msgctxt "StartupScreen"
 msgid "Simulates distortion caused by a real camera lens."
-msgstr ""
+msgstr "Simula a distorção causada por uma lente de câmara real."
 
 #: ../../Scripts/Gui/StartupScreen.as:1152
 #: ../../Scripts/Gui/StartupScreen.as:1153
 msgctxt "StartupScreen"
 msgid "Lens Scattering Filter"
-msgstr ""
+msgstr "Filtro de Dispersão de Lentes"
 
 #: ../../Scripts/Gui/StartupScreen.as:1153
 #: ../../Scripts/Gui/StartupScreen.as:1154
 msgctxt "StartupScreen"
 msgid "Simulates light being scattered by dust on the camera lens."
-msgstr ""
+msgstr "Simula a dispersão de luz pela poeira nas lentes da câmara."
 
 #: ../../Scripts/Gui/StartupScreen.as:1156
 #: ../../Scripts/Gui/StartupScreen.as:1157
 msgctxt "StartupScreen"
 msgid "Lens Flare"
-msgstr ""
+msgstr "Reflexo nas lentes"
 
 #: ../../Scripts/Gui/StartupScreen.as:1157
 #: ../../Scripts/Gui/StartupScreen.as:1158
 msgctxt "StartupScreen"
 msgid "The Sun causes lens flare."
-msgstr ""
+msgstr "O Sol causa reflexo nas lentes."
 
 #: ../../Scripts/Gui/StartupScreen.as:1159
 #: ../../Scripts/Gui/StartupScreen.as:1160
 msgctxt "StartupScreen"
 msgid "Flares for Dynamic Lights"
-msgstr ""
+msgstr "Reflexos para Luzes Dinâmicas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1160
 #: ../../Scripts/Gui/StartupScreen.as:1161
 msgctxt "StartupScreen"
 msgid "Enables lens flare for light sources other than the Sun."
-msgstr ""
+msgstr "Ativa o reflexo em lentes para fontes de luz diferentes do Sol."
 
 #: ../../Scripts/Gui/StartupScreen.as:1162
 #: ../../Scripts/Gui/StartupScreen.as:1163
 msgctxt "StartupScreen"
 msgid "Color Correction"
-msgstr ""
+msgstr "Correção de Cor"
 
 #: ../../Scripts/Gui/StartupScreen.as:1163
 #: ../../Scripts/Gui/StartupScreen.as:1164
 msgctxt "StartupScreen"
 msgid "Applies cinematic color correction to make the image look better."
-msgstr ""
+msgstr "Aplica correção de cor cinemática para tornar melhor a imagem."
 
 #: ../../Scripts/Gui/StartupScreen.as:1165
 #: ../../Scripts/Gui/StartupScreen.as:1166
 msgctxt "StartupScreen"
 msgid "Depth of Field"
-msgstr ""
+msgstr "Profundidade do Campo de Visão"
 
 #: ../../Scripts/Gui/StartupScreen.as:1166
 #: ../../Scripts/Gui/StartupScreen.as:1167
 msgctxt "StartupScreen"
 msgid "Blurs out-of-focus objects."
-msgstr ""
+msgstr "Desfoca objetos fora do campo de visão."
 
 #: ../../Scripts/Gui/StartupScreen.as:1168
 #: ../../Scripts/Gui/StartupScreen.as:1206
@@ -1212,7 +1242,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1229
 msgctxt "StartupScreen"
 msgid "Low"
-msgstr ""
+msgstr "Baixo"
 
 #: ../../Scripts/Gui/StartupScreen.as:1169
 #: ../../Scripts/Gui/StartupScreen.as:1207
@@ -1220,7 +1250,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1208
 msgctxt "StartupScreen"
 msgid "Medium"
-msgstr ""
+msgstr "Médio"
 
 #: ../../Scripts/Gui/StartupScreen.as:1170
 #: ../../Scripts/Gui/StartupScreen.as:1208
@@ -1230,13 +1260,13 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1231
 msgctxt "StartupScreen"
 msgid "High"
-msgstr ""
+msgstr "Alto"
 
 #: ../../Scripts/Gui/StartupScreen.as:1173
 #: ../../Scripts/Gui/StartupScreen.as:1174
 msgctxt "StartupScreen"
 msgid "Post-process"
-msgstr ""
+msgstr "Pós-Processamento"
 
 #: ../../Scripts/Gui/StartupScreen.as:1174
 #: ../../Scripts/Gui/StartupScreen.as:1175
@@ -1244,6 +1274,7 @@ msgctxt "StartupScreen"
 msgid ""
 "Post-process modifies the image to make it look better and more realistic."
 msgstr ""
+"O Pós-processamento modifica a imagem para parecer melhor e mais realista."
 
 #: ../../Scripts/Gui/StartupScreen.as:1181
 #: ../../Scripts/Gui/StartupScreen.as:1182
@@ -1253,12 +1284,16 @@ msgid ""
 "Medium:Particle intersects objects smoothly.|High:Particle intersects "
 "objects smoothly, and some objects casts their shadow to particles."
 msgstr ""
+"Partículas|Poucas:Artefactos ocorrem quando a partícula interseta outro "
+"objeto.|Algumas:Partículas intersetam objetos sem problemas.|Muitas:"
+"Partículas intersetam objetos sem problemas, alguns objetos transmitem a sua "
+"sombra para estas."
 
 #: ../../Scripts/Gui/StartupScreen.as:1191
 #: ../../Scripts/Gui/StartupScreen.as:1192
 msgctxt "StartupScreen"
 msgid "Dynamic Lights"
-msgstr ""
+msgstr "Luzes Dinâmicas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1193
 #: ../../Scripts/Gui/StartupScreen.as:1194
@@ -1267,24 +1302,26 @@ msgid ""
 "Gives some objects an ability to emit light to give them an energy-emitting "
 "impression."
 msgstr ""
+"Dá a habilidade de emitir luz a alguns objetos para lhes dar uma impressão "
+"de emitir energia."
 
 #: ../../Scripts/Gui/StartupScreen.as:1196
 #: ../../Scripts/Gui/StartupScreen.as:1197
 msgctxt "StartupScreen"
 msgid "Shadows"
-msgstr ""
+msgstr "Sombras"
 
 #: ../../Scripts/Gui/StartupScreen.as:1197
 #: ../../Scripts/Gui/StartupScreen.as:1198
 msgctxt "StartupScreen"
 msgid "Non-static object casts a shadow."
-msgstr ""
+msgstr "Objetos não-estáticos possuem sombra."
 
 #: ../../Scripts/Gui/StartupScreen.as:1199
 #: ../../Scripts/Gui/StartupScreen.as:1200
 msgctxt "StartupScreen"
 msgid "Volumetric Fog"
-msgstr ""
+msgstr "Névoa Volumétrica"
 
 #: ../../Scripts/Gui/StartupScreen.as:1200
 #: ../../Scripts/Gui/StartupScreen.as:1201
@@ -1293,12 +1330,14 @@ msgid ""
 "Simulates shadow being casted to the fog particles using a super highly "
 "computationally demanding algorithm. "
 msgstr ""
+"Simula a projeção de sombra para as partículas do nevoeiro usando um "
+"algoritmo exigente altamente computacional."
 
 #: ../../Scripts/Gui/StartupScreen.as:1203
 #: ../../Scripts/Gui/StartupScreen.as:1204
 msgctxt "StartupScreen"
 msgid "Physically Based Lighting"
-msgstr ""
+msgstr "Iluminação baseada fisicamente"
 
 #: ../../Scripts/Gui/StartupScreen.as:1204
 #: ../../Scripts/Gui/StartupScreen.as:1205
@@ -1306,13 +1345,13 @@ msgctxt "StartupScreen"
 msgid ""
 "Uses more accurate approximation techniques to decide the brightness of "
 "objects."
-msgstr ""
+msgstr "Usa técnicas de aproximação melhores que decidem o brilho dos objetos."
 
 #: ../../Scripts/Gui/StartupScreen.as:1211
 #: ../../Scripts/Gui/StartupScreen.as:1212
 msgctxt "StartupScreen"
 msgid "Direct Lights"
-msgstr ""
+msgstr "Luzes Diretas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1212
 #: ../../Scripts/Gui/StartupScreen.as:1213
@@ -1321,6 +1360,8 @@ msgid ""
 "Controls how light encounting a material and atmosphere directly affects its "
 "appearance."
 msgstr ""
+"Controlam como a luz reage ao encontrar um material e como a atmosfera afeta "
+"diretamente a sua aparência"
 
 #: ../../Scripts/Gui/StartupScreen.as:1222
 #: ../../Scripts/Gui/StartupScreen.as:1223
@@ -1332,30 +1373,35 @@ msgid ""
 "and refractions are rendered at the highest quality using screen-space "
 "techniques."
 msgstr ""
+"Shaders da Água|Nenhum:A água é renderizada da mesma maneira que os blocos "
+"normais.|Nível 1:Refração e a reflexão do sol são simuladas.|Nível 2:As "
+"ondas da água são simuladas assim como a reflexão e a refração.|Nível 3:"
+"Reflexões e refrações são renderizadas na qualidade máxima usando técnicas "
+"do espaço do ecrã."
 
 #: ../../Scripts/Gui/StartupScreen.as:1229
 #: ../../Scripts/Gui/StartupScreen.as:1230
 msgctxt "StartupScreen"
 msgid "Med"
-msgstr ""
+msgstr "Méd"
 
 #: ../../Scripts/Gui/StartupScreen.as:1231
 #: ../../Scripts/Gui/StartupScreen.as:1232
 msgctxt "StartupScreen"
 msgid "Ultra"
-msgstr ""
+msgstr "Ultra"
 
 #: ../../Scripts/Gui/StartupScreen.as:1234
 #: ../../Scripts/Gui/StartupScreen.as:1235
 msgctxt "StartupScreen"
 msgid "Shader Effects"
-msgstr ""
+msgstr "Efeitos do Shader"
 
 #: ../../Scripts/Gui/StartupScreen.as:1234
 #: ../../Scripts/Gui/StartupScreen.as:1235
 msgctxt "StartupScreen"
 msgid "Special effects."
-msgstr ""
+msgstr "Efeitos especiais."
 
 #: ../../Scripts/Gui/StartupScreen.as:1251
 #: ../../Scripts/Gui/StartupScreen.as:1252
@@ -1364,18 +1410,20 @@ msgid ""
 "Fast Mode:Reduces the image resolution to make the rendering faster.|Off|2x|"
 "4x"
 msgstr ""
+"Modo Rápido:Reduz a resolução da imagem para renderizar mais depressa.|Off|"
+"2x|4x"
 
 #: ../../Scripts/Gui/StartupScreen.as:1464
 #: ../../Scripts/Gui/StartupScreen.as:1465
 msgctxt "StartupScreen"
 msgid "Audio Settings"
-msgstr ""
+msgstr "Definições de Som"
 
 #: ../../Scripts/Gui/StartupScreen.as:1473
 #: ../../Scripts/Gui/StartupScreen.as:1474
 msgctxt "StartupScreen"
 msgid "OpenAL"
-msgstr ""
+msgstr "OpenAL"
 
 #: ../../Scripts/Gui/StartupScreen.as:1477
 #: ../../Scripts/Gui/StartupScreen.as:1478
@@ -1384,12 +1432,14 @@ msgid ""
 "Uses an OpenAL-capable sound card to process sound. In most cases where "
 "there isn't such a sound card, software emulation is used."
 msgstr ""
+"Usa uma placa de som capaz de processar som com OpenAL. Em alguns casos, "
+"quando não existe nenhuma, a emulação por software é usada."
 
 #: ../../Scripts/Gui/StartupScreen.as:1486
 #: ../../Scripts/Gui/StartupScreen.as:1487
 msgctxt "StartupScreen"
 msgid "YSR"
-msgstr ""
+msgstr "YSR"
 
 #: ../../Scripts/Gui/StartupScreen.as:1490
 #: ../../Scripts/Gui/StartupScreen.as:1491
@@ -1399,18 +1449,20 @@ msgid ""
 "features several enhanced features including automatic load control, "
 "dynamics compressor, HRTF-based 3D audio, and high quality reverb."
 msgstr ""
+"YSR é um motor de som experimental e optimizado para o OpenSpades. Utiliza "
+"várias funcion"
 
 #: ../../Scripts/Gui/StartupScreen.as:1500
 #: ../../Scripts/Gui/StartupScreen.as:1501
 msgctxt "StartupScreen"
 msgid "Null"
-msgstr ""
+msgstr "Nulo"
 
 #: ../../Scripts/Gui/StartupScreen.as:1504
 #: ../../Scripts/Gui/StartupScreen.as:1505
 msgctxt "StartupScreen"
 msgid "Disables audio output."
-msgstr ""
+msgstr "Desativa a saída de som."
 
 #: ../../Scripts/Gui/StartupScreen.as:1515
 #: ../../Scripts/Gui/StartupScreen.as:1539
@@ -1418,7 +1470,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1540
 msgctxt "StartupScreen"
 msgid "Polyphonics"
-msgstr ""
+msgstr "Polifónicos"
 
 #: ../../Scripts/Gui/StartupScreen.as:1516
 #: ../../Scripts/Gui/StartupScreen.as:1517
@@ -1428,12 +1480,15 @@ msgid ""
 "more processing power, so setting this too high might cause an overload "
 "(especially with a software emulation)."
 msgstr ""
+"Especifica quantos sons podem ser tocados em simultâneo. Valores mais altos "
+"necessitam de mais processamento, então, se estiver muito alta, pode causar "
+"sobrecarregamento. (especialmente em software)"
 
 #: ../../Scripts/Gui/StartupScreen.as:1523
 #: ../../Scripts/Gui/StartupScreen.as:1524
 msgctxt "StartupScreen"
 msgid "EAX"
-msgstr ""
+msgstr "EAX"
 
 #: ../../Scripts/Gui/StartupScreen.as:1524
 #: ../../Scripts/Gui/StartupScreen.as:1525
@@ -1442,6 +1497,8 @@ msgid ""
 "Enables extended features provided by the OpenAL driver to create more "
 "ambience."
 msgstr ""
+"Ativa as funcionalidades avançadas disponibilizadas pelo OpenAL para criar "
+"mais ambiente."
 
 #: ../../Scripts/Gui/StartupScreen.as:1540
 #: ../../Scripts/Gui/StartupScreen.as:1541
@@ -1450,12 +1507,14 @@ msgid ""
 "Specifies how many sounds can be played simultaneously. No matter what value "
 "is set, YSR might reduce the number of sounds when an overload is detected."
 msgstr ""
+"Especifica quantos sons podem ser tocados em simultâneo. Não interessa qual "
+"o valor, o YSR vai reduzir o número de sons quando sobrecarregar."
 
 #: ../../Scripts/Gui/StartupScreen.as:1600
 #: ../../Scripts/Gui/StartupScreen.as:1601
 msgctxt "StartupScreen"
 msgid "Language"
-msgstr ""
+msgstr "Linguagem"
 
 #: ../../Scripts/Gui/StartupScreen.as:1657
 #: ../../Scripts/Gui/StartupScreen.as:1703
@@ -1463,7 +1522,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1726
 msgctxt "StartupScreen"
 msgid "Unknown ({0})"
-msgstr ""
+msgstr "Desconhecido ({0})"
 
 #: ../../Scripts/Gui/StartupScreen.as:1659
 #: ../../Scripts/Gui/StartupScreen.as:1673
@@ -1475,7 +1534,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1742
 msgctxt "StartupScreen"
 msgid "System default"
-msgstr ""
+msgstr "Predefinição do Sistema"
 
 #: ../../Scripts/Gui/StartupScreen.as:1722
 #: ../../Scripts/Gui/StartupScreen.as:1768
@@ -1483,7 +1542,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1791
 msgctxt "StartupScreen"
 msgid "Copy to Clipboard"
-msgstr ""
+msgstr "Copiar para a Área de Trans."
 
 #: ../../Scripts/Gui/StartupScreen.as:1758
 #: ../../Scripts/Gui/StartupScreen.as:1804
@@ -1491,7 +1550,7 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1827
 msgctxt "StartupScreen"
 msgid "Advanced Settings"
-msgstr ""
+msgstr "Definições Avançadas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1767
 #: ../../Scripts/Gui/StartupScreen.as:1813
@@ -1499,22 +1558,22 @@ msgstr ""
 #: ../../Scripts/Gui/StartupScreen.as:1836
 msgctxt "StartupScreen"
 msgid "Filter"
-msgstr ""
+msgstr "Filtro"
 
 #: ../../Scripts/Gui/MessageBox.as:144
 msgctxt "MessageBox"
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: ../../Scripts/Gui/StartupScreen.as:1613
 msgctxt "StartupScreen"
 msgid "Reset"
-msgstr ""
+msgstr "Resetar"
 
 #: ../../Scripts/Gui/StartupScreen.as:1616
 msgctxt "StartupScreen"
 msgid "Reset All Settings"
-msgstr ""
+msgstr "Resetar Todas as Definições"
 
 #: ../../Scripts/Gui/StartupScreen.as:1628
 #: ../../Scripts/Gui/StartupScreen.as:1652
@@ -1522,24 +1581,25 @@ msgctxt "StartupScreen"
 msgid ""
 "Are you sure to reset all settings? They include (but are not limited to):"
 msgstr ""
+"Deseja resetar todas as definições? isto inclui (mas não está limitado a):"
 
 #: ../../Scripts/Gui/StartupScreen.as:1629
 #: ../../Scripts/Gui/StartupScreen.as:1653
 msgctxt "StartupScreen"
 msgid "All graphics/audio settings"
-msgstr ""
+msgstr "Todas as definições gráficas/som"
 
 #: ../../Scripts/Gui/StartupScreen.as:1630
 #: ../../Scripts/Gui/StartupScreen.as:1654
 msgctxt "StartupScreen"
 msgid "All key bindings"
-msgstr ""
+msgstr "Todas as teclas definidas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1631
 #: ../../Scripts/Gui/StartupScreen.as:1655
 msgctxt "StartupScreen"
 msgid "Your player name"
-msgstr ""
+msgstr "O teu nome de Jogador"
 
 #: ../../Scripts/Gui/StartupScreen.as:1633
 #: ../../Scripts/Gui/StartupScreen.as:1632
@@ -1549,28 +1609,49 @@ msgid ""
 "Other advanced settings only accessible through '{0}' tab and in-game "
 "commands"
 msgstr ""
+"Outras definições avançadas podem ser apenas acessíveis através do separador "
+"'{0} e em comandos de jogo"
 
 #: ../../Scripts/Gui/StartupScreen.as:1613
 msgctxt "StartupScreen"
 msgid "Tools"
-msgstr ""
+msgstr "Ferramentas"
 
 #: ../../Scripts/Gui/StartupScreen.as:1646
 msgctxt "StartupScreen"
 msgid "An unknown error has occurred while opening the config directory."
 msgstr ""
+"Um erro desconhecido ocorreu enquanto se abria o diretório de configurações."
 
 #: ../../Scripts/Gui/StartupScreen.as:1625
 msgctxt "StartupScreen"
 msgid "Open Config Folder in Explorer"
-msgstr ""
+msgstr "Abrir a Pasta de Configs. no Explorador"
 
 #: ../../Scripts/Gui/StartupScreen.as:1627
 msgctxt "StartupScreen"
 msgid "Reveal Config Folder in Finder"
-msgstr ""
+msgstr "Revelar a Pasta de Configs. no Finder"
 
 #: ../../Scripts/Gui/StartupScreen.as:1629
 msgctxt "StartupScreen"
 msgid "Browse Config Folder"
+msgstr "Abrir a Pasta de Configs."
+
+msgctxt "Preferences"
+msgid "Weapon Spread Guide"
+msgstr "Depurar Propagação de Balas"
+
+msgctxt "StartupScreen"
+msgid ""
+"Water Shader|None:Water is rendered in the same way that normal blocks are "
+"done.|Level 1:Refraction and the reflected Sun are simulated.|Level 2:Waving "
+"water is simulated as well as reflection and refraction."
 msgstr ""
+"Shader de Água|Nenhum:A água é renderizada da mesma maneira que os blocos.|"
+"Level 1:Refração e o Sol refletido são simulados.|Level 1:Ondas de água são "
+"simulados assim como a reflexão e a refração."
+
+msgctxt "Preferences"
+msgid "Debug Hit Detection"
+msgstr "Depurar Deteção de Colisão"

--- a/Resources/Locales/ru/openspades.po
+++ b/Resources/Locales/ru/openspades.po
@@ -1208,7 +1208,7 @@ msgstr "Фильтр"
 #: ../../Scripts/Gui/StartupScreen.as:1071
 msgctxt "StartupScreen"
 msgid ""
-"Antialias:Enables a technique to improve the appearance of high-constrast "
+"Antialias:Enables a technique to improve the appearance of high-contrast "
 "edges.\n"
 "\n"
 "MSAA: Performs antialiasing by generating an intermediate high-resolution "

--- a/Resources/Scripts/Gui/StartupScreen.as
+++ b/Resources/Scripts/Gui/StartupScreen.as
@@ -1123,7 +1123,7 @@ namespace spades {
 				cfg.AddRow(StartupScreenConfigSelectItemEditor(ui,
 					StartupScreenGraphicsAntialiasConfig(ui), "0|2|4|fxaa",
 					_Tr("StartupScreen",
-					"Antialias:Enables a technique to improve the appearance of high-constrast edges.\n\n"
+					"Antialias:Enables a technique to improve the appearance of high-contrast edges.\n\n"
 					"MSAA: Performs antialiasing by generating an intermediate high-resolution image. "
 					"Looks best, but doesn't cope with some settings.\n\n"
 					"FXAA: Performs antialiasing by smoothing artifacts out as a post-process.|"


### PR DESCRIPTION
I'm requesting this pull in order of adding support to **Portuguese** language and fixing typos found on **POT** - base language (which caused to change on the other languages) and **pt_BR**.
Additionally, on the JSON that identifies the languages, I've changed "_Portuguese_" to "_Portuguese (Brazil)_" and created the pt_PT.json to identify the _Portuguese (Portugal)_ language.

_PS: There might be things that can be slightly equal between Portuguese (Portugal) and Portuguese (Brazil), since both languages are based from the same language, only the regional changes._