### PR TITLE
Update README.md to add snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ OpenSpades is a compatible client of Ace of Spades 0.75.
  2. Or [open an issue](https://github.com/yvt/openspades/issues) if the problem persists
 
 ### On Linux
+
+On [snap enabled](https://snapcraft.io/docs/core/install) systems, the latest pre-built stable release of OpenSpades can be installed with:-
+
+   snap install openspades
+   
+Once installed, the OpenSpades icon will appear in the menu, or it can be launched from the terminal with ```openspades```.
+
 GCC 4.9 / Clang 3.2 or later is recommended because OpenSpades relies on C++11 features heavily.
 
 1. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ OpenSpades is a compatible client of Ace of Spades 0.75.
  2. Or [open an issue](https://github.com/yvt/openspades/issues) if the problem persists
 
 ### On Linux
+#### Snap package
+On [snap enabled](https://snapcraft.io/docs/core/install) systems, the latest pre-built stable release of OpenSpades can be installed with:
 
-On [snap enabled](https://snapcraft.io/docs/core/install) systems, the latest pre-built stable release of OpenSpades can be installed with:-
+```bash
+snap install openspades
+```
 
-   snap install openspades
-   
-Once installed, the OpenSpades icon will appear in the menu, or it can be launched from the terminal with ```openspades```.
+Once installed, you'll be able to launch OpenSpades from inside the desktop menu or from your terminal with the `openspades` command.
 
+#### Building and installing from source
 GCC 4.9 / Clang 3.2 or later is recommended because OpenSpades relies on C++11 features heavily.
 
 1. Install dependencies:


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable developers and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install openspades` simplifying the installation instructions for your users.

I uploaded the snap to the store and tested it on numerous Linux distros. The config is in PR #612 and as mentioned there, I'm happy to hand the keys over to you guys if you want to upload to the store. 