### PR TITLE
Skip dead players when spectating between spawns

### DIFF
--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -59,6 +59,8 @@ DEFINE_SPADES_SETTING(cg_chatBeep, "1");
 
 DEFINE_SPADES_SETTING(cg_serverAlert, "1");
 
+DEFINE_SPADES_SETTING(cg_SkipDeadPlayersWhenDead, "1");
+
 SPADES_SETTING(cg_playerName);
 
 namespace spades {
@@ -715,7 +717,8 @@ namespace spades {
 					continue;
 				if (myTeam < 2 && p->GetTeamId() != myTeam)
 					continue;
-				if (myTeam < 2 && !p->IsAlive())
+
+				if (myTeam < 2 && cg_SkipDeadPlayersWhenDead && !p->IsAlive())
 					// Skip dead players when not spectator
 					continue;
 				if (p->GetFront().GetPoweredLength() < .01f)

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -715,6 +715,9 @@ namespace spades {
 					continue;
 				if (myTeam < 2 && p->GetTeamId() != myTeam)
 					continue;
+				if (myTeam < 2 && !p->IsAlive())
+					// Skip dead players when not spectator
+					continue;
 				if (p->GetFront().GetPoweredLength() < .01f)
 					continue;
 


### PR DESCRIPTION
This makes e.g. spectating the last player alive in arena easier