### PR TITLE
Adjust the gain of hit feedback sound

### DIFF
--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -51,6 +51,7 @@
 DEFINE_SPADES_SETTING(cg_ragdoll, "1");
 SPADES_SETTING(cg_blood);
 DEFINE_SPADES_SETTING(cg_ejectBrass, "1");
+DEFINE_SPADES_SETTING(cg_hitFeedbackSoundGain, "0.2");
 
 SPADES_SETTING(cg_alerts);
 SPADES_SETTING(cg_centerMessage);
@@ -962,8 +963,8 @@ namespace spades {
 					Handle<IAudioChunk> c =
 					  audioDevice->RegisterSound("Sounds/Feedback/HeadshotFeedback.opus");
 					AudioParam param;
-					param.volume = 10.f;
-					audioDevice->Play(c, hitPos, param);
+					param.volume = cg_hitFeedbackSoundGain;
+					audioDevice->PlayLocal(c, param);
 				}
 				
 				hitFeedbackIconState = 1.f;


### PR DESCRIPTION
Fixes #652.

The sound gain is now constant and does not change regardless of the distance. This imitates the behavior often seen in other first-person shooters. The default gain is adjusted to the level that I feel most comfortable.

Switching from `Play` to `PlayLocal` only affects the way the gain is computed since `HeadshotFeedback.opus` is a stereo sound file and therefore not spatialized by any known audio backends.

This also introduces a config variable named `cg_hitFeedbackSoundGain` that allows users to adjust the volume of the hit feedback sound.