### PR TITLE
Alert player when building above highest z-level

### DIFF
--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -428,6 +428,7 @@ namespace spades {
 				if (result.hit && (result.hitBlock + result.normal).z < 62 &&
 				    (!OverlapsWithOneBlock(result.hitBlock + result.normal)) &&
 				    BoxDistanceToBlock(result.hitBlock + result.normal) < 3.f &&
+				    (result.hitBlock + result.normal).z >= 0 &&
 				    !pendingPlaceBlock) {
 
 					// Building is possible, and there's no delayed block placement.


### PR DESCRIPTION
Made it so that an alert is displayed when the player attempts to build beyond the highest z-level (e.g. above the platform in babel.)

This also fixes a bug where blocks are consumed when attempting to do such thing.