### PR TITLE
Add color coding to ping

### DIFF
--- a/Resources/Scripts/Gui/MainScreen.as
+++ b/Resources/Scripts/Gui/MainScreen.as
@@ -220,8 +220,21 @@ namespace spades {
 			Font.Draw(item.Name, ScreenPosition + Vector2(4.f, 2.f), 1.f, fgcolor);
 
 			int ping = helper.GetServerPing(item.Address);
+			Vector4 pingColor;
+			if(ping < 90) {
+				pingColor = Vector4(0.7f, 1, 0.7f, 1); // Green
+			}
+			else if (ping < 120) {
+				pingColor = Vector4(1, 1, 0.7f, 1); // Yellow
+			}
+			else if (ping < 200) {
+				pingColor = Vector4(1, .9f, 0.7f, 1); // Orange
+			}
+			else {
+				pingColor = Vector4(1, 0.7f, 0.7f, 1); // Red
+			}
 			string pingStr = ping == -1 ? "" : ToString(ping);
-			Font.Draw(pingStr, ScreenPosition + Vector2(335.f-Font.Measure(pingStr).x, 2.f), 1.f, Vector4(1,1,1,1));
+			Font.Draw(pingStr, ScreenPosition + Vector2(335.f-Font.Measure(pingStr).x, 2.f), 1.f, pingColor);
 
 			string playersStr = ToString(item.NumPlayers) + "/" + ToString(item.MaxPlayers);
 			Vector4 col(1,1,1,1);


### PR DESCRIPTION
Currently, the following steps are used:
 * <90: green
 * <120: yellow
 * <200: orange
 * >200: red

It currently looks waaay to colorful. I think a colored bar or something might
look best, but for now this works and lets you quickly see how good you can
expect the connection to be