### PR TITLE
Flashlight fixes

### DIFF
--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -617,7 +617,8 @@ namespace spades {
 			                                    eyeMatrix.GetOrigin() + Vector3(20.f, 20.f, 20.f)));
 			sandboxedRenderer->SetAllowDepthHack(true);
 
-			if (client->flashlightOn) {
+			// no flashlight if spectating other players while dead
+			if (client->flashlightOn && world->GetLocalPlayer()->IsAlive()) {
 				float brightness;
 				brightness = client->time - client->flashlightOnTime;
 				brightness = 1.f - expf(-brightness * 5.f);

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -558,6 +558,9 @@ namespace spades {
 					} else if (CheckKey(cg_keySaveMap, name) && down) {
 						TakeMapShot();
 					} else if (CheckKey(cg_keyFlashlight, name) && down) {
+						// spectators and dead players should not be able to toggle the flashlight
+						if (world->GetLocalPlayer()->IsSpectator() || !world->GetLocalPlayer()->IsAlive())
+							return;
 						flashlightOn = !flashlightOn;
 						flashlightOnTime = time;
 						Handle<IAudioChunk> chunk =


### PR DESCRIPTION
Dead players and spectators may no longer toggle the flashlight, spectating other players while dead will keep your flashlight off
Closes: #731 