### PR TITLE
Do not overwrite User Resource Directory on every snap launch

### DIFF
--- a/snap/scripts/launch_openspades
+++ b/snap/scripts/launch_openspades
@@ -10,9 +10,9 @@ case "$SNAP_ARCH" in
 	;;
 esac
 
-if [ ! -f $SNAP_USER_DATA/.local/share/openspades/Resources ];
+if [ ! -d $SNAP_USER_DATA/.local/share/openspades/Resources ];
 then
-  mkdir -p $SNAP_USER_DATA/.local/share/openspades/Resources
+	mkdir -p $SNAP_USER_DATA/.local/share/openspades/Resources
 	cp $SNAP/share/games/openspades/Resources/* $SNAP_USER_DATA/.local/share/openspades/Resources
 	echo cl_checkForUpdates: 1 > $SNAP_USER_DATA/.local/share/openspades/Resources/SPConfig.cfg
 	echo s_eax: 1 >> $SNAP_USER_DATA/.local/share/openspades/Resources/SPConfig.cfg


### PR DESCRIPTION
-f was being used instead of -d for checking the User Resource Directory existence.
Also, remove an indentation inconsistency in the script.

Hopefully fixes #667.

I didn't test it, but it's quite likely it works.