### PR TITLE
Explicitly delete a reference to SDL surface when a window is closed

### DIFF
--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		E8690AE91D3920C800DBC331 /* pak010-BaseSkin.pak */ = {isa = PBXFileReference; lastKnownFileType = file; name = "pak010-BaseSkin.pak"; path = "Resources/pak010-BaseSkin.pak"; sourceTree = "<group>"; };
 		E8690AEA1D3920C800DBC331 /* pak050-Locales.pak */ = {isa = PBXFileReference; lastKnownFileType = file; name = "pak050-Locales.pak"; path = "Resources/pak050-Locales.pak"; sourceTree = "<group>"; };
 		E8690AEB1D3920C800DBC331 /* pak999-References.pak */ = {isa = PBXFileReference; lastKnownFileType = file; name = "pak999-References.pak"; path = "Resources/pak999-References.pak"; sourceTree = "<group>"; };
+		E86D20D12171BF9700964257 /* Disposable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Disposable.h; sourceTree = "<group>"; };
 		E8725DAB1DE33B4D003BC987 /* NoiseSampler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NoiseSampler.cpp; sourceTree = "<group>"; };
 		E8725DAC1DE33B4D003BC987 /* NoiseSampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NoiseSampler.h; sourceTree = "<group>"; };
 		E874834618EACF0300C29033 /* OpenSpades.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = OpenSpades.icns; path = Resources/Icons/OpenSpades.icns; sourceTree = "<group>"; };
@@ -1588,6 +1589,7 @@
 				E89A5F1D1DF8732200857F65 /* ShellApi.h */,
 				E89A5F1F1DF8759200857F65 /* ShellApi.mm */,
 				E8655AA91DFC0AAA00D5058A /* TMPUtils.h */,
+				E86D20D12171BF9700964257 /* Disposable.h */,
 			);
 			path = Core;
 			sourceTree = "<group>";

--- a/Sources/Core/Disposable.h
+++ b/Sources/Core/Disposable.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2018 yvt
 
  This file is part of OpenSpades.
 
@@ -17,29 +17,18 @@
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
-
 #pragma once
 
-#include <Core/Bitmap.h>
-#include <Core/RefCountedObject.h>
+#include "RefCountedObject.h"
 
 namespace spades {
-	namespace draw {
-		class SWPort : public virtual RefCountedObject {
-		protected:
-			~SWPort() {}
 
-		public:
-			/**
-			 * Returns a `Bitmap` on which the scene is rendered.
-			 */
-			virtual Bitmap *GetFramebuffer() = 0;
+	/**
+	 * Implements explicit finalization semantics.
+	 */
+	class Disposable: public virtual RefCountedObject {
+	public:
+		virtual void Dispose() {}
+	};
 
-			/**
-			 * Presents the contents of the framebuffer (returned by
-			 * `GetFramebuffer`) to the screen.
-			 */
-			virtual void Swap() = 0;
-		};
-	}
 }

--- a/Sources/Core/RefCountedObject.h
+++ b/Sources/Core/RefCountedObject.h
@@ -67,6 +67,8 @@ namespace spades {
 
 		template <class S> Handle(Handle<S> &&h) : ptr(h.MaybeUnmanage()) {}
 
+		template <class S> operator Handle<S>() && { return {std::move(*this)}; }
+
 		~Handle() {
 			if (ptr)
 				ptr->Release();

--- a/Sources/Gui/SDLRunner.cpp
+++ b/Sources/Gui/SDLRunner.cpp
@@ -409,11 +409,15 @@ namespace spades {
 				case RendererType::GL: {
 					auto glDevice = Handle<SDLGLDevice>::New(wnd);
 					auto dummy = Handle<Disposable>::New(); // FIXME
-					return {Handle<draw::GLRenderer>::New(glDevice), std::move(dummy)};
+					return std::make_tuple(
+					  Handle<draw::GLRenderer>::New(glDevice).Cast<client::IRenderer>(),
+					  std::move(dummy));
 				}
 				case RendererType::SW: {
 					auto port = Handle<SDLSWPort>::New(wnd);
-					return {Handle<draw::SWRenderer>::New(port), std::move(port)};
+					return std::make_tuple(
+					  Handle<draw::SWRenderer>::New(port).Cast<client::IRenderer>(),
+					  std::move(port).Cast<Disposable>());
 				}
 				default: SPRaise("Invalid renderer type");
 			}

--- a/Sources/Gui/SDLRunner.h
+++ b/Sources/Gui/SDLRunner.h
@@ -21,9 +21,11 @@
 #pragma once
 
 #include <string>
+#include <tuple>
 
 #include <Imports/SDL.h>
 
+#include <Core/Disposable.h>
 #include <Core/IRunnable.h>
 #include <Core/ServerAddress.h>
 
@@ -50,7 +52,7 @@ namespace spades {
 			virtual void RunClientLoop(client::IRenderer *renderer, client::IAudioDevice *dev);
 			virtual View *CreateView(client::IRenderer *renderer, client::IAudioDevice *dev) = 0;
 			virtual client::IAudioDevice *CreateAudioDevice();
-			client::IRenderer *CreateRenderer(SDL_Window *);
+			std::tuple<Handle<client::IRenderer>, Handle<Disposable>> CreateRenderer(SDL_Window *);
 
 		public:
 			SDLRunner();


### PR DESCRIPTION
This issue was identified by #775. (Hopefully) fixes #779.