### PR TITLE
Update CMake policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ set(OS_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(CMAKE_PREFIX_PATH Sources/Externals)
 
-if(POLICY CMP0054)
-	# Escape variables in if
-	cmake_policy(SET CMP0054 OLD)
+# Prefer GLVND OpenGL
+if(POLICY CMP0072)
+	cmake_policy(SET CMP0072 NEW)
 endif()
 
 include(cmake/FindSDL2.cmake)


### PR DESCRIPTION
Closes #776, closes #762 

CMP0054 works just fine with either OLD or NEW settings with our build system, so no need to explicitly set it to deprecated behaviour.

CMP0072 was set to NEW, now preferring GLVND (GL Vendor-Neutral Dispatch) instead of the legacy OpenGL libraries. GLVND allows multiple vendor implementations to coexist on the filesystem, amongst other things. (See also: https://www.x.org/wiki/Events/XDC2017/brenneman_GLVND.pdf)

I tested those changes in my system and OpenSpades builds and runs (including in-game) just fine.