### PR TITLE
detect end of map transfer with state packet

### DIFF
--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -315,8 +315,6 @@ namespace spades {
 
 			PlayerInput actualInput = player->GetInput();
 			WeaponInput actualWeapInput = player->GetWeaponInput();
-			Vector3 vel = player->GetVelocty();
-			vel.z = 0.f;
 			if (actualInput.sprint && player->IsAlive()) {
 				sprintState += dt * 4.f;
 				if (sprintState > 1.f)

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -592,15 +592,13 @@ namespace spades {
 									throw;
 								}
 								HandleGamePacket(reader);
-							} else if (reader.GetType() == PacketTypeVersionGet) {
-								// Packets that should be handled now even when
-								// the map is downloading
-								HandleGamePacket(reader);
-							} else if (reader.GetType() != PacketTypeWeaponReload) {
+							} else if (reader.GetType() == PacketTypeWeaponReload) {
 								// Drop the reload packet. Pyspades does not
 								// cancel the reload packets on map change and
 								// they would cause an error if we would
 								// process them
+							} else  {
+								// Save the packet for later
 								savedPackets.push_back(reader.GetData());
 							}
 						}


### PR DESCRIPTION
Previously, the end of map transfer was detected by a number of fallible
heuristics, including checking if the map is loadable on every non-map
packet, when a timeout had been reached, or the map size given by the
server was reached. This broke in a number of scenarios, including when
an unexpected packet was sent.

Instead, we now detect the end of the map transfer when we receive a
state packet, as intended by the protocol.

I have tested that this works for:
 - initial map load
 - map advances
 - map advances with pending reloads

Fixes #826 