### PR TITLE
Display a real progress bar when receiving a map

### DIFF
--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		E83668AF1E05757B00977A63 /* OpusAudioStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E83668AD1E05757B00977A63 /* OpusAudioStream.cpp */; };
 		E83668B21E05844E00977A63 /* AudioStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E83668B01E05844E00977A63 /* AudioStream.cpp */; };
 		E8403CA8229061BF00093C3E /* RandomAccessAdaptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */; };
+		E8403CAB229123CF00093C3E /* PipeStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CA9229123CF00093C3E /* PipeStream.cpp */; };
 		E8626EAE1E1009D7003365BF /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E844888617D26699005105D0 /* libcurl.tbd */; };
 		E8626EB61E100EC6003365BF /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB51E100EC6003365BF /* libfreetype.a */; };
 		E8626EB81E100FB2003365BF /* libogg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB71E100FB2003365BF /* libogg.a */; };
@@ -425,6 +426,8 @@
 		E838D42018ADDE2800EE3C53 /* StringsScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringsScript.cpp; sourceTree = "<group>"; };
 		E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RandomAccessAdaptor.cpp; sourceTree = "<group>"; };
 		E8403CA7229061BE00093C3E /* RandomAccessAdaptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RandomAccessAdaptor.h; sourceTree = "<group>"; };
+		E8403CA9229123CF00093C3E /* PipeStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PipeStream.cpp; sourceTree = "<group>"; };
+		E8403CAA229123CF00093C3E /* PipeStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipeStream.h; sourceTree = "<group>"; };
 		E842888918A3CF6C0060743D /* StartupScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreen.cpp; sourceTree = "<group>"; };
 		E842888A18A3CF6C0060743D /* StartupScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StartupScreen.h; sourceTree = "<group>"; };
 		E842888C18A3D1520060743D /* StartupScreenHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreenHelper.cpp; sourceTree = "<group>"; };
@@ -1837,6 +1840,8 @@
 		E8E44681179CC49C00BE8855 /* I/O */ = {
 			isa = PBXGroup;
 			children = (
+				E8403CA9229123CF00093C3E /* PipeStream.cpp */,
+				E8403CAA229123CF00093C3E /* PipeStream.h */,
 				E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */,
 				E8403CA7229061BE00093C3E /* RandomAccessAdaptor.h */,
 				E8B6B72617E5AC9C00E35523 /* ServerAddress.cpp */,
@@ -2025,6 +2030,7 @@
 				E82E67E918EA7A51004DBA18 /* list.c in Sources */,
 				E82E67EA18EA7A51004DBA18 /* packet.c in Sources */,
 				E82E67EB18EA7A51004DBA18 /* peer.c in Sources */,
+				E8403CAB229123CF00093C3E /* PipeStream.cpp in Sources */,
 				E81012311E1D7301009955D3 /* Icon.cpp in Sources */,
 				E8A2EBA01F5BE16D00E39CD9 /* GameProperties.cpp in Sources */,
 				E82E67EC18EA7A51004DBA18 /* protocol.c in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		E83668B21E05844E00977A63 /* AudioStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E83668B01E05844E00977A63 /* AudioStream.cpp */; };
 		E8403CA8229061BF00093C3E /* RandomAccessAdaptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */; };
 		E8403CAB229123CF00093C3E /* PipeStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CA9229123CF00093C3E /* PipeStream.cpp */; };
+		E8403CAE2291280800093C3E /* GameMapLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CAD2291280700093C3E /* GameMapLoader.cpp */; };
 		E8626EAE1E1009D7003365BF /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E844888617D26699005105D0 /* libcurl.tbd */; };
 		E8626EB61E100EC6003365BF /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB51E100EC6003365BF /* libfreetype.a */; };
 		E8626EB81E100FB2003365BF /* libogg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB71E100FB2003365BF /* libogg.a */; };
@@ -428,6 +429,8 @@
 		E8403CA7229061BE00093C3E /* RandomAccessAdaptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RandomAccessAdaptor.h; sourceTree = "<group>"; };
 		E8403CA9229123CF00093C3E /* PipeStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PipeStream.cpp; sourceTree = "<group>"; };
 		E8403CAA229123CF00093C3E /* PipeStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipeStream.h; sourceTree = "<group>"; };
+		E8403CAC2291280700093C3E /* GameMapLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameMapLoader.h; sourceTree = "<group>"; };
+		E8403CAD2291280700093C3E /* GameMapLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameMapLoader.cpp; sourceTree = "<group>"; };
 		E842888918A3CF6C0060743D /* StartupScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreen.cpp; sourceTree = "<group>"; };
 		E842888A18A3CF6C0060743D /* StartupScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StartupScreen.h; sourceTree = "<group>"; };
 		E842888C18A3D1520060743D /* StartupScreenHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreenHelper.cpp; sourceTree = "<group>"; };
@@ -1728,6 +1731,8 @@
 		E8E0AF9017993D1800C6B5A9 /* Net */ = {
 			isa = PBXGroup;
 			children = (
+				E8403CAD2291280700093C3E /* GameMapLoader.cpp */,
+				E8403CAC2291280700093C3E /* GameMapLoader.h */,
 				E8F6E6E41DCF503200FE76BB /* MumbleLink.cpp */,
 				E8F6E6E51DCF503200FE76BB /* MumbleLink.h */,
 				E834F55117944778004EBE88 /* NetClient.cpp */,
@@ -2200,6 +2205,7 @@
 				E82E67C918EA7972004DBA18 /* Fonts.cpp in Sources */,
 				E82E67CA18EA7972004DBA18 /* IGameMode.cpp in Sources */,
 				E82E67CB18EA7972004DBA18 /* CTFGameMode.cpp in Sources */,
+				E8403CAE2291280800093C3E /* GameMapLoader.cpp in Sources */,
 				E82E67CC18EA7972004DBA18 /* TCGameMode.cpp in Sources */,
 				E82E67CD18EA7972004DBA18 /* Player.cpp in Sources */,
 				E82E67CE18EA7972004DBA18 /* Grenade.cpp in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		E82E680418EA7F60004DBA18 /* libysrspades.dylib in Resources */ = {isa = PBXBuildFile; fileRef = E82E680318EA7F60004DBA18 /* libysrspades.dylib */; };
 		E83668AF1E05757B00977A63 /* OpusAudioStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E83668AD1E05757B00977A63 /* OpusAudioStream.cpp */; };
 		E83668B21E05844E00977A63 /* AudioStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E83668B01E05844E00977A63 /* AudioStream.cpp */; };
+		E8403CA8229061BF00093C3E /* RandomAccessAdaptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */; };
 		E8626EAE1E1009D7003365BF /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E844888617D26699005105D0 /* libcurl.tbd */; };
 		E8626EB61E100EC6003365BF /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB51E100EC6003365BF /* libfreetype.a */; };
 		E8626EB81E100FB2003365BF /* libogg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E8626EB71E100FB2003365BF /* libogg.a */; };
@@ -422,6 +423,8 @@
 		E838D41D18AC726B00EE3C53 /* Strings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Strings.cpp; sourceTree = "<group>"; };
 		E838D41E18AC726B00EE3C53 /* Strings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Strings.h; sourceTree = "<group>"; };
 		E838D42018ADDE2800EE3C53 /* StringsScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringsScript.cpp; sourceTree = "<group>"; };
+		E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RandomAccessAdaptor.cpp; sourceTree = "<group>"; };
+		E8403CA7229061BE00093C3E /* RandomAccessAdaptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RandomAccessAdaptor.h; sourceTree = "<group>"; };
 		E842888918A3CF6C0060743D /* StartupScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreen.cpp; sourceTree = "<group>"; };
 		E842888A18A3CF6C0060743D /* StartupScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StartupScreen.h; sourceTree = "<group>"; };
 		E842888C18A3D1520060743D /* StartupScreenHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StartupScreenHelper.cpp; sourceTree = "<group>"; };
@@ -1834,6 +1837,8 @@
 		E8E44681179CC49C00BE8855 /* I/O */ = {
 			isa = PBXGroup;
 			children = (
+				E8403CA6229061BE00093C3E /* RandomAccessAdaptor.cpp */,
+				E8403CA7229061BE00093C3E /* RandomAccessAdaptor.h */,
 				E8B6B72617E5AC9C00E35523 /* ServerAddress.cpp */,
 				E8B6B72717E5AC9C00E35523 /* ServerAddress.h */,
 				E8CF04091790471D000683D4 /* IFileSystem.cpp */,
@@ -1956,6 +1961,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -2042,6 +2048,7 @@
 				E82E674018EA7972004DBA18 /* as_callfunc_xenon.cpp in Sources */,
 				E82E674118EA7972004DBA18 /* as_compiler.cpp in Sources */,
 				E82E674218EA7972004DBA18 /* as_configgroup.cpp in Sources */,
+				E8403CA8229061BF00093C3E /* RandomAccessAdaptor.cpp in Sources */,
 				E82E674318EA7972004DBA18 /* as_context.cpp in Sources */,
 				E82E674418EA7972004DBA18 /* as_datatype.cpp in Sources */,
 				E82E674518EA7972004DBA18 /* as_gc.cpp in Sources */,

--- a/Resources/Locales/pot/openspades.pot
+++ b/Resources/Locales/pot/openspades.pot
@@ -304,11 +304,6 @@ msgctxt "NetClient"
 msgid "Loading snapshot"
 msgstr ""
 
-#: Sources/Client/NetClient.cpp:523
-msgctxt "NetClient"
-msgid "Loading snapshot ({0}/{1})"
-msgstr ""
-
 #: Sources/Client/NetClient.cpp:528 Sources/Client/NetClient.cpp:562
 msgctxt "NetClient"
 msgid "Connected"
@@ -1588,3 +1583,17 @@ msgstr ""
 msgctxt "Client"
 msgid "[{0}/{1}] Go up/down"
 msgstr ""
+
+#: Sources/Client/NetClient.cpp:1883
+msgctxt "NetClient"
+msgid "{0} second remaining"
+msgid_plural "{0} seconds remaining"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Sources/Client/NetClient.cpp:1885
+msgctxt "NetClient"
+msgid "{0} minute remaining"
+msgid_plural "{0} minutes remaining"
+msgstr[0] ""
+msgstr[1] ""

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -431,6 +431,21 @@ namespace spades {
 			killfeedWindow->Update(dt);
 			limbo->Update(dt);
 
+			// The loading screen
+			if (net->GetStatus() == NetClientStatusReceivingMap) {
+				// Apply temporal smoothing on the progress value
+				float progress = net->GetMapReceivingProgress();
+
+				if (mapReceivingProgressSmoothed > progress) {
+					mapReceivingProgressSmoothed = progress;
+				} else {
+					mapReceivingProgressSmoothed +=
+					  (progress - mapReceivingProgressSmoothed) * (1.0 - powf(.05f, dt));
+				}
+			} else {
+				mapReceivingProgressSmoothed = 0.0;
+			}
+
 			// CreateSceneDefinition also can be used for sounds
 			SceneDefinition sceneDef = CreateSceneDefinition();
 			lastSceneDef = sceneDef;

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -313,6 +313,9 @@ namespace spades {
 			float alertDisappearTime;
 			float alertAppearTime;
 
+			// Loading screen
+			float mapReceivingProgressSmoothed = 0.0;
+
 			std::list<std::unique_ptr<ILocalEntity>> localEntities;
 			std::list<std::unique_ptr<Corpse>> corpses;
 			Corpse *lastMyCorpse;

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -867,20 +867,34 @@ namespace spades {
 			           MakeVector4(1, 1, 1, 0.95f));
 
 			img = renderer->RegisterImage("Gfx/White.tga");
-			float pos = timeSinceInit / 3.6f;
-			pos -= floorf(pos);
-			pos = 1.f - pos * 2.0f;
-			for (float v = 0; v < 0.6f; v += 0.14f) {
-				float p = pos + v;
-				if (p < 0.01f || p > .99f)
-					continue;
-				p = asin(p * 2.f - 1.f);
-				p = p / (float)M_PI + 0.5f;
 
-				float op = p * (1.f - p) * 4.f;
-				renderer->SetColorAlphaPremultiplied(MakeVector4(op, op, op, op));
+			if (net->GetStatus() == NetClientStatusReceivingMap) {
+				// Normal progress bar
+				float progress = net->GetMapReceivingProgress();
+
+				renderer->SetColorAlphaPremultiplied(MakeVector4(0.2f, 0.2f, 0.2f, 0.2f));
+				renderer->DrawImage(img, AABB2(scrWidth - 236.f, scrHeight - 18.f, 222.f, 4.f));
+
+				renderer->SetColorAlphaPremultiplied(MakeVector4(1.0f, 1.0f, 1.0f, 1.0f));
 				renderer->DrawImage(
-				  img, AABB2(scrWidth - 236.f + p * 234.f, scrHeight - 18.f, 4.f, 4.f));
+				  img, AABB2(scrWidth - 236.f, scrHeight - 18.f, 222.f * progress, 4.f));
+			} else {
+				// Indeterminate progress bar
+				float pos = timeSinceInit / 3.6f;
+				pos -= floorf(pos);
+				pos = 1.f - pos * 2.0f;
+				for (float v = 0; v < 0.6f; v += 0.14f) {
+					float p = pos + v;
+					if (p < 0.01f || p > .99f)
+						continue;
+					p = asin(p * 2.f - 1.f);
+					p = p / (float)M_PI + 0.5f;
+
+					float op = p * (1.f - p) * 4.f;
+					renderer->SetColorAlphaPremultiplied(MakeVector4(op, op, op, op));
+					renderer->DrawImage(
+					  img, AABB2(scrWidth - 236.f + p * 234.f, scrHeight - 18.f, 4.f, 4.f));
+				}
 			}
 
 			DrawAlert();

--- a/Sources/Client/Client_Draw.cpp
+++ b/Sources/Client/Client_Draw.cpp
@@ -870,7 +870,7 @@ namespace spades {
 
 			if (net->GetStatus() == NetClientStatusReceivingMap) {
 				// Normal progress bar
-				float progress = net->GetMapReceivingProgress();
+				float progress = mapReceivingProgressSmoothed;
 
 				renderer->SetColorAlphaPremultiplied(MakeVector4(0.2f, 0.2f, 0.2f, 0.2f));
 				renderer->DrawImage(img, AABB2(scrWidth - 236.f, scrHeight - 18.f, 222.f, 4.f));

--- a/Sources/Client/GameMap.cpp
+++ b/Sources/Client/GameMap.cpp
@@ -525,71 +525,71 @@ namespace spades {
 
 			Handle<GameMap> map{new GameMap(), false};
 
-				for (int y = 0; y < 512; y++) {
-					for (int x = 0; x < 512; x++) {
-						map->solidMap[x][y] = 0xffffffffffffffffULL;
+			for (int y = 0; y < 512; y++) {
+				for (int x = 0; x < 512; x++) {
+					map->solidMap[x][y] = 0xffffffffffffffffULL;
 
-						if (pos + 2 >= len) {
+					if (pos + 2 >= len) {
+						SPRaise("File truncated");
+					}
+
+					int z = 0;
+					for (;;) {
+						int i;
+						uint32_t *color;
+						int number_4byte_chunks = bytes[pos];
+						int top_color_start = bytes[pos + 1];
+						int top_color_end = bytes[pos + 2];
+						int bottom_color_start;
+						int bottom_color_end;
+						int len_top;
+						int len_bottom;
+
+						for (i = z; i < top_color_start; i++)
+							map->Set(x, y, i, false, 0, true);
+
+						if (pos + 4 + top_color_end - top_color_start + 3 >= len) {
 							SPRaise("File truncated");
 						}
 
-						int z = 0;
-						for (;;) {
-							int i;
-							uint32_t *color;
-							int number_4byte_chunks = bytes[pos];
-							int top_color_start = bytes[pos + 1];
-							int top_color_end = bytes[pos + 2];
-							int bottom_color_start;
-							int bottom_color_end;
-							int len_top;
-							int len_bottom;
+						color = (uint32_t *)(bytes.data() + pos + 4);
+						for (z = top_color_start; z <= top_color_end; z++)
+							map->Set(x, y, z, true, swapColor(*(color++)), true);
 
-							for (i = z; i < top_color_start; i++)
-								map->Set(x, y, i, false, 0, true);
+						if (top_color_end == 62) {
+							map->Set(x, y, 63, true, map->GetColor(x, y, 62), true);
+						}
 
-							if (pos + 4 + top_color_end - top_color_start + 3 >= len) {
-								SPRaise("File truncated");
-							}
+						len_bottom = top_color_end - top_color_start + 1;
 
-							color = (uint32_t *)(bytes.data() + pos + 4);
-							for (z = top_color_start; z <= top_color_end; z++)
-								map->Set(x, y, z, true, swapColor(*(color++)), true);
+						if (number_4byte_chunks == 0) {
+							pos += 4 * (len_bottom + 1);
+							break;
+						}
 
-							if (top_color_end == 62) {
-								map->Set(x, y, 63, true, map->GetColor(x, y, 62), true);
-							}
+						len_top = (number_4byte_chunks - 1) - len_bottom;
 
-							len_bottom = top_color_end - top_color_start + 1;
+						pos += (int)bytes[pos] * 4;
 
-							if (number_4byte_chunks == 0) {
-								pos += 4 * (len_bottom + 1);
-								break;
-							}
+						if (pos + 3 >= len) {
+							SPRaise("File truncated");
+						}
 
-							len_top = (number_4byte_chunks - 1) - len_bottom;
+						bottom_color_end = bytes[pos + 3];
+						bottom_color_start = bottom_color_end - len_top;
 
-							pos += (int)bytes[pos] * 4;
-
-							if (pos + 3 >= len) {
-								SPRaise("File truncated");
-							}
-
-							bottom_color_end = bytes[pos + 3];
-							bottom_color_start = bottom_color_end - len_top;
-
-							for (z = bottom_color_start; z < bottom_color_end; z++) {
-								uint32_t col = swapColor(*(color++));
-								map->Set(x, y, z, true, col, true);
-							}
-							if (bottom_color_end == 63) {
-								map->Set(x, y, 63, true, map->GetColor(x, y, 62), true);
-							}
+						for (z = bottom_color_start; z < bottom_color_end; z++) {
+							uint32_t col = swapColor(*(color++));
+							map->Set(x, y, z, true, col, true);
+						}
+						if (bottom_color_end == 63) {
+							map->Set(x, y, 63, true, map->GetColor(x, y, 62), true);
 						}
 					}
 				}
+			}
 
 			return map.Unmanage();
 		}
-	}
-}
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/GameMap.cpp
+++ b/Sources/Client/GameMap.cpp
@@ -517,7 +517,7 @@ namespace spades {
 			return (u.c & 0xffffff) | (100UL * 0x1000000);
 		}
 
-		GameMap *GameMap::Load(spades::IStream *stream) {
+		GameMap *GameMap::Load(spades::IStream *stream, std::function<void(int)> onProgress) {
 			SPADES_MARK_FUNCTION();
 
 			RandomAccessAdaptor view{*stream};
@@ -525,6 +525,10 @@ namespace spades {
 			size_t pos = 0;
 
 			Handle<GameMap> map{new GameMap(), false};
+
+			if (onProgress) {
+				onProgress(0);
+			}
 
 			for (int y = 0; y < 512; y++) {
 				for (int x = 0; x < 512; x++) {
@@ -581,6 +585,10 @@ namespace spades {
 						if (bottom_color_end == 63) {
 							map->Set(x, y, 63, true, map->GetColor(x, y, 62), true);
 						}
+					}
+
+					if (onProgress) {
+						onProgress(x + y * 512 + 1);
 					}
 				}
 			}

--- a/Sources/Client/GameMap.h
+++ b/Sources/Client/GameMap.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <list>
 
 #include <Core/Debug.h>
@@ -48,7 +49,15 @@ namespace spades {
 			};
 			GameMap();
 
-			static GameMap *Load(IStream *);
+			/**
+			 * Construct a `GameMap` from VOXLAP5 terrain data supplied by the specified stream.
+			 *
+			 * @param onProgress Called whenever a new column (a set of voxels with the same X and Y
+			 *                   coordinates) is loaded from the stream. The parameter indicates
+			 *					 the number of columns loaded
+			 *					 (up to `DefaultWidth * DefaultHeight`).
+			 */
+			static GameMap *Load(IStream *, std::function<void(int)> onProgress = {});
 
 			void Save(IStream *);
 

--- a/Sources/Client/GameMapLoader.cpp
+++ b/Sources/Client/GameMapLoader.cpp
@@ -87,6 +87,7 @@ namespace spades {
 			rawDataReader = StreamHandle{};
 
 			decodingThread.reset(new Thread(&*decodingThreadRunnable));
+			decodingThread->Start();
 		}
 
 		GameMapLoader::~GameMapLoader() {
@@ -138,6 +139,7 @@ namespace spades {
 			SPAssert(IsComplete());
 
 			std::unique_ptr<Result> result = resultCell.take();
+			SPAssert(result);
 
 			if (result->gameMap) {
 				return result->gameMap.Unmanage();

--- a/Sources/Client/GameMapLoader.cpp
+++ b/Sources/Client/GameMapLoader.cpp
@@ -70,7 +70,7 @@ namespace spades {
 			}
 		};
 
-		GameMapLoader::GameMapLoader() {
+		GameMapLoader::GameMapLoader() : progressCell{0} {
 			SPADES_MARK_FUNCTION();
 
 			auto pipe = CreatePipeStream();

--- a/Sources/Client/GameMapLoader.cpp
+++ b/Sources/Client/GameMapLoader.cpp
@@ -1,0 +1,150 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include <exception>
+
+#include "GameMap.h"
+#include "GameMapLoader.h"
+#include <Core/Debug.h>
+#include <Core/DeflateStream.h>
+#include <Core/Exception.h>
+#include <Core/IRunnable.h>
+#include <Core/PipeStream.h>
+#include <Core/Thread.h>
+
+namespace spades {
+	namespace client {
+
+		struct GameMapLoader::Result {
+			// The following fields are mutually exclusive.
+			std::exception_ptr exceptionThrown;
+			Handle<GameMap> gameMap;
+		};
+
+		struct GameMapLoader::Decoder : public IRunnable {
+			GameMapLoader &parent;
+			StreamHandle rawDataReader;
+
+			Decoder(GameMapLoader &parent, StreamHandle rawDataReader)
+			    : parent{parent}, rawDataReader{rawDataReader} {}
+
+			void Run() override {
+				SPADES_MARK_FUNCTION();
+
+				std::unique_ptr<Result> result{new Result()};
+
+				try {
+					DeflateStream inflate(&*rawDataReader, CompressModeDecompress, false);
+
+					GameMap *gameMapPtr =
+					  GameMap::Load(&inflate, [this](int x) { HandleProgress(x); });
+
+					result->gameMap = Handle<GameMap>{gameMapPtr, false};
+				} catch (...) {
+					// Capture the current exception
+					result->exceptionThrown = std::current_exception();
+				}
+
+				// Send back the result
+				parent.resultCell.store(std::move(result));
+			}
+
+			void HandleProgress(int numColumnsLoaded) {
+				parent.progressCell.store(numColumnsLoaded);
+			}
+		};
+
+		GameMapLoader::GameMapLoader() {
+			SPADES_MARK_FUNCTION();
+
+			auto pipe = CreatePipeStream();
+
+			rawDataWriter = StreamHandle{std::get<0>(pipe)};
+			auto rawDataReader = StreamHandle{std::get<1>(pipe)};
+
+			decodingThreadRunnable.reset(new Decoder(*this, rawDataReader));
+
+			// Drop `rawDataReader` before the thread starts. `StreamHandle`'s internally
+			// ref-counted and it's not thread-safe. So, if we don't drop it here, there'll be
+			// a data race between the constructor of `Decoder` and the deconstruction of the local
+			// variable `rawDataReader`.
+			rawDataReader = StreamHandle{};
+
+			decodingThread.reset(new Thread(&*decodingThreadRunnable));
+		}
+
+		GameMapLoader::~GameMapLoader() {
+			SPADES_MARK_FUNCTION();
+
+			// Hang up the writer. This causes the decoder thread to exit gracefully.
+			rawDataWriter = StreamHandle{};
+
+			decodingThread->Join();
+			decodingThread.reset();
+		}
+
+		void GameMapLoader::AddRawChunk(const char *bytes, std::size_t numBytes) {
+			SPADES_MARK_FUNCTION();
+
+			if (!rawDataWriter) {
+				SPRaise("The raw data channel is already closed.");
+			}
+
+			rawDataWriter->Write(bytes, numBytes);
+		}
+
+		void GameMapLoader::MarkEOF() {
+			SPADES_MARK_FUNCTION();
+
+			if (!rawDataWriter) {
+				SPRaise("The raw data channel is already closed.");
+			}
+			rawDataWriter = StreamHandle{};
+		}
+
+		bool GameMapLoader::IsComplete() { return resultCell.operator bool(); }
+
+		void GameMapLoader::WaitComplete() {
+			SPADES_MARK_FUNCTION();
+
+			decodingThread->Join();
+
+			SPAssert(IsComplete());
+		}
+
+		float GameMapLoader::GetProgress() {
+			return static_cast<float>(progressCell.load(std::memory_order_relaxed)) / (512 * 512);
+		}
+
+		GameMap *GameMapLoader::TakeGameMap() {
+			SPADES_MARK_FUNCTION();
+
+			SPAssert(IsComplete());
+
+			std::unique_ptr<Result> result = resultCell.take();
+
+			if (result->gameMap) {
+				return result->gameMap.Unmanage();
+			} else {
+				std::rethrow_exception(result->exceptionThrown);
+			}
+		}
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/GameMapLoader.h
+++ b/Sources/Client/GameMapLoader.h
@@ -1,0 +1,105 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include <atomic>
+#include <memory>
+
+#include <Core/IStream.h>
+#include <Core/TMPUtils.h>
+
+namespace spades {
+	class Thread;
+	class IRunnable;
+
+	namespace client {
+
+		class GameMap;
+
+		/**
+		 * A streaming map loader that can decode a game map in a streaming fashion and
+		 * report the progress based on the incomplete decoded data.
+		 */
+		class GameMapLoader {
+		public:
+			GameMapLoader();
+			~GameMapLoader();
+
+			GameMapLoader(const GameMapLoader &) = delete;
+			void operator=(const GameMapLoader &) = delete;
+
+			/**
+			 * Adds undecoded data to the internal buffer for decoding.
+			 */
+			void AddRawChunk(const char *bytes, std::size_t numBytes);
+
+			/**
+			 * Notifies the decoder that there is no more undecoded data to process.
+			 */
+			void MarkEOF();
+
+			/**
+			 * Returns `true` if the loading operation is complete, successful or not.
+			 */
+			bool IsComplete();
+
+			/**
+			 * Blocks the current thread until the decoding is complete.
+			 * Make sure to call `MakeEOF` first or it might cause a deadlock.
+			 */
+			void WaitComplete();
+
+			/**
+			 * Gets how much portion of the map has completed loading.
+			 *
+			 * @return A value in range `[0, 1]`.
+			 */
+			float GetProgress();
+
+			/**
+			 * Gets the loaded `GameMap` and takes the ownership of it.
+			 *
+			 * `IsComplete()` must be `true`.
+			 *
+			 * If an exception occured while decoding the map, the exception will be rethrown when
+			 * this method is called.
+			 */
+			GameMap *TakeGameMap();
+
+		private:
+			struct Decoder;
+			struct Result;
+
+			/** A writable stream used to send undecoded data to the decoding thread. */
+			StreamHandle rawDataWriter;
+
+			/** A handle for the decoding thread. */
+			std::unique_ptr<Thread> decodingThread;
+
+			/** The `IRunnable` used to create `decodingThread`. Must outlive the thread. */
+			std::unique_ptr<IRunnable> decodingThreadRunnable;
+
+			/** The cell for receiving the decode progress. */
+			std::atomic_uint32_t progressCell;
+
+			/** The cell for receiving the decode result. */
+			stmp::atomic_unique_ptr<Result> resultCell;
+		};
+
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/GameMapLoader.h
+++ b/Sources/Client/GameMapLoader.h
@@ -95,7 +95,7 @@ namespace spades {
 			std::unique_ptr<IRunnable> decodingThreadRunnable;
 
 			/** The cell for receiving the decode progress. */
-			std::atomic_uint32_t progressCell;
+			std::atomic<std::uint32_t> progressCell;
 
 			/** The cell for receiving the decode result. */
 			stmp::atomic_unique_ptr<Result> resultCell;

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -67,8 +67,23 @@ namespace spades {
 			ENetPeer *peer;
 			std::string statusString;
 
+			class MapDownloadMonitor {
+				Stopwatch sw;
+				unsigned int numBytesDownloaded;
+				GameMapLoader &mapLoader;
+				bool receivedFirstByte;
+
+			public:
+				MapDownloadMonitor(GameMapLoader &);
+
+				void AccumulateBytes(unsigned int);
+				std::string GetDisplayedText();
+			};
+
 			/** Only valid in the `NetClientStatusReceivingMap` state */
 			std::unique_ptr<GameMapLoader> mapLoader;
+			/** Only valid in the `NetClientStatusReceivingMap` state */
+			std::unique_ptr<MapDownloadMonitor> mapLoadMonitor;
 
 			std::shared_ptr<GameProperties> properties;
 
@@ -135,7 +150,7 @@ namespace spades {
 
 			NetClientStatus GetStatus() { return status; }
 
-			std::string GetStatusString() { return statusString; }
+			std::string GetStatusString();
 
 			/**
 			 * Gets how much portion of the map has completed loading.

--- a/Sources/Client/NetClient.h
+++ b/Sources/Client/NetClient.h
@@ -58,14 +58,18 @@ namespace spades {
 		struct WeaponInput;
 		class Grenade;
 		struct GameProperties;
+		class GameMapLoader;
+
 		class NetClient {
 			Client *client;
 			NetClientStatus status;
 			ENetHost *host;
 			ENetPeer *peer;
 			std::string statusString;
-			unsigned int mapSize;
-			std::vector<char> mapData;
+
+			/** Only valid in the `NetClientStatusReceivingMap` state */
+			std::unique_ptr<GameMapLoader> mapLoader;
+
 			std::shared_ptr<GameProperties> properties;
 
 			int protocolVersion;
@@ -132,6 +136,14 @@ namespace spades {
 			NetClientStatus GetStatus() { return status; }
 
 			std::string GetStatusString() { return statusString; }
+
+			/**
+			 * Gets how much portion of the map has completed loading.
+			 * `GetStatus()` must be `NetClientStatusReceivingMap`.
+			 *
+			 * @return A value in range `[0, 1]`.
+			 */
+			float GetMapReceivingProgress();
 
 			/**
 			 * Return a non-null reference to `GameProperties` for this connection.

--- a/Sources/Core/IStream.cpp
+++ b/Sources/Core/IStream.cpp
@@ -136,8 +136,12 @@ namespace spades {
 		if (o != h.o) {
 			SharedStream *old = o;
 			o = h.o;
-			o->Retain();
-			old->Release();
+			if (o) {
+				o->Retain();
+			}
+			if (old) {
+				old->Release();
+			}
 		}
 		return *this;
 	}

--- a/Sources/Core/IStream.cpp
+++ b/Sources/Core/IStream.cpp
@@ -152,6 +152,8 @@ namespace spades {
 		return o->stream;
 	}
 
+	StreamHandle::operator bool() const { return o->stream; }
+
 	void StreamHandle::Reset() {
 		if (o) {
 			o->Release();

--- a/Sources/Core/IStream.h
+++ b/Sources/Core/IStream.h
@@ -87,5 +87,6 @@ namespace spades {
 		void Reset();
 		IStream *operator->() const;
 		operator IStream *() const;
+		operator bool() const;
 	};
 }

--- a/Sources/Core/PipeStream.cpp
+++ b/Sources/Core/PipeStream.cpp
@@ -126,7 +126,7 @@ namespace spades {
 					state->condvar.wait(
 					  lock, [&] { return !state->buffer.empty() || state->writerHangup; });
 
-					if (state->writerHangup) {
+					if (state->writerHangup && state->buffer.empty()) {
 						break;
 					}
 

--- a/Sources/Core/PipeStream.cpp
+++ b/Sources/Core/PipeStream.cpp
@@ -1,0 +1,161 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include <algorithm>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+
+#include "PipeStream.h"
+
+namespace spades {
+	namespace {
+		struct State {
+			/** Protects the state from simultaneous access. */
+			std::mutex mutex;
+			/** Used to notify changes in the state. */
+			std::condition_variable condvar;
+
+			/**
+			 * The ring buffer.
+			 *
+			 * Might not be the most efficient choice... But it has a good time complexity.
+			 */
+			std::deque<char> buffer;
+
+			/** `true` if the writer has hanged up. */
+			bool writerHangup = false;
+
+			/** `true` if the reader has hanged up. */
+			bool readerHangup = false;
+		};
+
+		struct PipeWriter : public IStream {
+			std::shared_ptr<State> state;
+
+			PipeWriter(std::shared_ptr<State> state) : state{std::move(state)} {}
+
+			~PipeWriter() {
+				{
+					std::lock_guard<std::mutex> _lock{state->mutex};
+					state->writerHangup = true;
+				}
+
+				// The reader must stop waiting
+				state->condvar.notify_one();
+			}
+
+			void WriteByte(int byte) override {
+				auto value = static_cast<std::uint8_t>(byte);
+				Write(&value, 1);
+			}
+
+			void Write(const void *data, size_t numBytes) override {
+				{
+					std::lock_guard<std::mutex> _lock{state->mutex};
+
+					auto inputBytes = reinterpret_cast<const char *>(data);
+
+					if (state->readerHangup) {
+						return;
+					}
+
+					// Allocate the space for incoming bytes
+					size_t prevSize = state->buffer.size();
+					state->buffer.resize(prevSize + numBytes);
+
+					for (auto it = state->buffer.begin() + prevSize; it != state->buffer.end();
+					     ++it) {
+						*it = *(inputBytes++);
+					}
+				}
+
+				// Wake up the reader
+				state->condvar.notify_one();
+			}
+		};
+
+		struct PipeReader : public IStream {
+			std::shared_ptr<State> state;
+
+			PipeReader(std::shared_ptr<State> state) : state{std::move(state)} {}
+
+			~PipeReader() {
+				std::lock_guard<std::mutex> _lock{state->mutex};
+				state->readerHangup = true;
+
+				// Deallocate the ring buffer
+				std::deque<char> other;
+				state->buffer.swap(other);
+			}
+
+			int ReadByte() override {
+				std::uint8_t value;
+				if (Read(&value, 1)) {
+					return value;
+				} else {
+					return -1;
+				}
+			}
+
+			size_t Read(void *data, size_t numBytes) override {
+				auto outputBytes = reinterpret_cast<char *>(data);
+				size_t numActualRead = 0;
+
+				std::unique_lock<std::mutex> lock{state->mutex};
+
+				while (numActualRead < numBytes) {
+					state->condvar.wait(
+					  lock, [&] { return !state->buffer.empty() || state->writerHangup; });
+
+					if (state->writerHangup) {
+						break;
+					}
+
+					// Copy data from the ring buffer
+					size_t numAdditionalBytes =
+					  std::min(state->buffer.size(), numBytes - numActualRead);
+					auto it = state->buffer.begin();
+					for (; numAdditionalBytes; --numAdditionalBytes, ++it) {
+						*(outputBytes++) = *it;
+
+						++numActualRead;
+					}
+
+					// Update the ring buffer
+					state->buffer.erase(state->buffer.begin(), it);
+				}
+
+				return numActualRead;
+			}
+		};
+
+	} // namespace
+
+	std::tuple<IStream *, IStream *> CreatePipeStream() {
+		auto state = std::make_shared<State>();
+
+		return {
+		  new PipeWriter(state),
+		  new PipeReader(state),
+		};
+	}
+} // namespace spades

--- a/Sources/Core/PipeStream.cpp
+++ b/Sources/Core/PipeStream.cpp
@@ -153,9 +153,6 @@ namespace spades {
 	std::tuple<IStream *, IStream *> CreatePipeStream() {
 		auto state = std::make_shared<State>();
 
-		return {
-		  new PipeWriter(state),
-		  new PipeReader(state),
-		};
+		return std::make_tuple(new PipeWriter(state), new PipeReader(state));
 	}
 } // namespace spades

--- a/Sources/Core/PipeStream.h
+++ b/Sources/Core/PipeStream.h
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include <tuple>
+
+#include <Core/IStream.h>
+
+namespace spades {
+	/**
+	 * Create a pipe and return a pair of streams for writing and reading,
+	 * respectively.
+	 *
+	 * Hanging up behaviours:
+	 *  - If the writer hangs up, the reader will get an EOF for further reads.
+	 *  - If the reader hangs up, the writer silently discards the written data.
+	 */
+	std::tuple<IStream *, IStream *> CreatePipeStream();
+} // namespace spades

--- a/Sources/Core/RandomAccessAdaptor.cpp
+++ b/Sources/Core/RandomAccessAdaptor.cpp
@@ -21,7 +21,7 @@
 
 #include <Core/Exception.h>
 #include <Core/IStream.h>
-#include <string>
+#include <cstring>
 
 namespace spades {
 	RandomAccessAdaptor::RandomAccessAdaptor(IStream &inner) : inner{inner} {}

--- a/Sources/Core/RandomAccessAdaptor.cpp
+++ b/Sources/Core/RandomAccessAdaptor.cpp
@@ -1,0 +1,75 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include "RandomAccessAdaptor.h"
+
+#include <Core/Exception.h>
+#include <Core/IStream.h>
+#include <string>
+
+namespace spades {
+	RandomAccessAdaptor::RandomAccessAdaptor(IStream &inner) : inner{inner} {}
+
+	RandomAccessAdaptor::~RandomAccessAdaptor() {
+		// Do nothing - the buffer is automatically taken care of
+	}
+
+	void RandomAccessAdaptor::ExpandTo(std::size_t newBufferSize) {
+		if (newBufferSize <= buffer.size()) {
+			return;
+		}
+
+		std::size_t numAdditionalBytes = newBufferSize - buffer.size();
+		std::size_t originalSize = buffer.size();
+
+		try {
+			// Expand the internal buffer
+			buffer.resize(newBufferSize);
+
+			// Read additional bytes from the underlying stream to the newly
+			// allocated space of the internal buffer
+			std::size_t numBytesRead = inner.Read(buffer.data() + originalSize, numAdditionalBytes);
+
+			// Shrink the buffer to the actual read size
+			buffer.resize(originalSize + numBytesRead);
+		} catch (...) {
+			// Roll back to the original state
+			buffer.resize(originalSize);
+			throw;
+		}
+	}
+
+	bool RandomAccessAdaptor::TryRead(std::size_t offset, std::size_t size, char *output) {
+		std::size_t newLen = offset + size;
+		if (newLen < offset) {
+			// `newLen` overflowed `size_t`.
+			SPRaise("integer overflow");
+		}
+
+		ExpandTo(newLen);
+
+		if (buffer.size() < newLen) {
+			// Reached EOF
+			return false;
+		}
+
+		std::memcpy(output, buffer.data() + offset, size);
+		return true;
+	}
+} // namespace spades

--- a/Sources/Core/RandomAccessAdaptor.cpp
+++ b/Sources/Core/RandomAccessAdaptor.cpp
@@ -19,6 +19,7 @@
  */
 #include "RandomAccessAdaptor.h"
 
+#include <Core/Debug.h>
 #include <Core/Exception.h>
 #include <Core/IStream.h>
 #include <cstring>
@@ -34,6 +35,8 @@ namespace spades {
 		if (newBufferSize <= buffer.size()) {
 			return;
 		}
+
+		SPADES_MARK_FUNCTION();
 
 		std::size_t numAdditionalBytes = newBufferSize - buffer.size();
 		std::size_t originalSize = buffer.size();
@@ -56,6 +59,8 @@ namespace spades {
 	}
 
 	bool RandomAccessAdaptor::TryRead(std::size_t offset, std::size_t size, char *output) {
+		SPADES_MARK_FUNCTION();
+
 		std::size_t newLen = offset + size;
 		if (newLen < offset) {
 			// `newLen` overflowed `size_t`.

--- a/Sources/Core/RandomAccessAdaptor.h
+++ b/Sources/Core/RandomAccessAdaptor.h
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include <vector>
+
+#include <Core/TMPUtils.h>
+
+namespace spades {
+	class IStream;
+
+	/**
+	 * Wraps a read-only stream to provide a random-accessible view into the data using a
+	 * dynamically-growing internal buffer.
+	 */
+	class RandomAccessAdaptor {
+	public:
+		/**
+		 * Constructs a `RandomAccessAdaptor` using the specified stream to supply the data read
+		 * through the view.
+		 *
+		 * The specified stream must outlive the uses of the constructed `RandomAccessAdaptor`.
+		 */
+		RandomAccessAdaptor(IStream &inner);
+
+		/**
+		 * De-initializes a `RandomAcesssAdaptor` and release all resources associates with it.
+		 *
+		 * Note that the wrapped stream is not closed by this finalizer.
+		 */
+		~RandomAccessAdaptor();
+
+		/**
+		 * Try to read the value of type `T` at the specified offset.
+		 *
+		 * Various complicated rules regarding reinterpretation apply, so it's not generally
+		 * a good idea to specfiy a non-POD type as `T`.
+		 *
+		 * `offset + sizeof(T)` must not overflow `size_t`. An exception is thrown in such a case,
+		 * but probably should abort the program in the future.
+		 */
+		template <class T> stmp::optional<T> TryRead(std::size_t offset) {
+			T data;
+			if (TryRead(offset, sizeof(T), reinterpret_cast<char *>(&data))) {
+				return {data};
+			} else {
+				return {};
+			}
+		}
+
+	private:
+		/**
+		 * Tries to ensure `buffer` is at least `newBufferSize` bytes long.
+		 *
+		 * The final size might be less than `newBufferSize` if an EOF is reached. This function is
+		 * exception-safe - `buffer` is left in the original state if an exception occurs while
+		 * reading the inner stream.
+		 */
+		void ExpandTo(std::size_t newBufferSize);
+
+		/**
+		 * Try to read `size` bytes at the specified offset to `output`.
+		 *
+		 * @return `true` if all of the bytes could be read.
+		 */
+		bool TryRead(std::size_t offset, std::size_t size, char *output);
+
+		IStream &inner;
+		std::vector<char> buffer;
+	};
+} // namespace spades

--- a/Sources/Core/RandomAccessAdaptor.h
+++ b/Sources/Core/RandomAccessAdaptor.h
@@ -17,8 +17,10 @@
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
+#include <algorithm>
 #include <vector>
 
+#include <Core/Exception.h>
 #include <Core/TMPUtils.h>
 
 namespace spades {
@@ -60,6 +62,21 @@ namespace spades {
 				return {data};
 			} else {
 				return {};
+			}
+		}
+
+		/**
+		 * Read the value of type `T` at the specified offset. Throws an exception if an EOF is
+		 * reached.
+		 *
+		 * See also: `TryRead`.
+		 */
+		template <class T> T Read(std::size_t offset) {
+			auto data = TryRead<T>(offset);
+			if (data) {
+				return std::move(*data);
+			} else {
+				SPRaise("Unexpected EOF");
 			}
 		}
 

--- a/Sources/Core/RandomAccessAdaptor.h
+++ b/Sources/Core/RandomAccessAdaptor.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <vector>
 
+#include <Core/Debug.h>
 #include <Core/Exception.h>
 #include <Core/TMPUtils.h>
 
@@ -57,6 +58,8 @@ namespace spades {
 		 * but probably should abort the program in the future.
 		 */
 		template <class T> stmp::optional<T> TryRead(std::size_t offset) {
+			SPADES_MARK_FUNCTION();
+
 			T data;
 			if (TryRead(offset, sizeof(T), reinterpret_cast<char *>(&data))) {
 				return {data};
@@ -76,6 +79,7 @@ namespace spades {
 			if (data) {
 				return std::move(*data);
 			} else {
+				SPADES_MARK_FUNCTION();
 				SPRaise("Unexpected EOF");
 			}
 		}

--- a/Sources/Core/RandomAccessAdaptor.h
+++ b/Sources/Core/RandomAccessAdaptor.h
@@ -84,6 +84,15 @@ namespace spades {
 			}
 		}
 
+		/**
+		 * Read the inner stream ahead to make the internal buffer at least `length` bytes long.
+		 */
+		void Prefetch(std::size_t length) {
+			SPADES_MARK_FUNCTION();
+
+			ExpandTo(length);
+		}
+
 	private:
 		/**
 		 * Tries to ensure `buffer` is at least `newBufferSize` bytes long.

--- a/Sources/Core/TMPUtils.h
+++ b/Sources/Core/TMPUtils.h
@@ -166,6 +166,8 @@ namespace stmp {
 		void operator=(const atomic_unique_ptr &) = delete;
 		void operator=(atomic_unique_ptr &&x) { exchange(x.take()); }
 
+		operator bool() const { return inner.load() != nullptr; }
+
 		inline std::unique_ptr<T>
 		unsafe_exchange(std::unique_ptr<T> &&desired,
 		                std::memory_order order = std::memory_order_seq_cst) {


### PR DESCRIPTION
This PR introduces a *real* progress bar displaying how much percentage of a map has been downloaded, instead of just the number of bytes downloaded, which didn't give players an idea how long it would take.

![progressbar](https://user-images.githubusercontent.com/5253988/57979611-23a2df80-7a5b-11e9-8aaf-492f6f07cb2f.png)

`MapStart` is useless for this purpose because the server doesn't know the compressed size at the point when `MapStart` is sent due to progressive compression and just sends [a constant value](https://github.com/piqueserver/piqueserver/blob/05447fe32bacf7c5630654577140092d4f4e48be/pyspades/mapgenerator.py#L36-L41). The approach taken here is to start decoding the map data as it's being received and examine the amount of the decoded data. The correspondence between the decoded size and the compressed size is not linear, but gives players a better idea how longer the receiving process is going to take.