### PR TITLE
Add internal console window

### DIFF
--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		E8C7D7B122DA35F000F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */; };
 		E8C7D7B422DAF5B500F78763 /* ConsoleCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */; };
 		E8C7D7BA22DB220300F78763 /* ConfigConsoleResponder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */; };
+		E8C7D7BE22DB2A4400F78763 /* ConsoleCommandCandidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -771,6 +772,9 @@
 		E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommand.cpp; sourceTree = "<group>"; };
 		E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConfigConsoleResponder.cpp; sourceTree = "<group>"; };
 		E8C7D7B922DB220300F78763 /* ConfigConsoleResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigConsoleResponder.h; sourceTree = "<group>"; };
+		E8C7D7BB22DB263200F78763 /* Iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iterator.h; sourceTree = "<group>"; };
+		E8C7D7BC22DB2A4400F78763 /* ConsoleCommandCandidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleCommandCandidate.h; sourceTree = "<group>"; };
+		E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommandCandidate.cpp; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1510,6 +1514,8 @@
 		E8CF039D178EDDBF000683D4 /* Gui */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */,
+				E8C7D7BC22DB2A4400F78763 /* ConsoleCommandCandidate.h */,
 				E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */,
 				E8C7D7B922DB220300F78763 /* ConfigConsoleResponder.h */,
 				E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */,
@@ -1588,6 +1594,7 @@
 		E8CF03AF178EE2CD000683D4 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7BB22DB263200F78763 /* Iterator.h */,
 				E8E44682179CC4A400BE8855 /* Media */,
 				E8E44681179CC49C00BE8855 /* I/O */,
 				E8E44680179CC48B00BE8855 /* System */,
@@ -2095,6 +2102,7 @@
 				E82E674C18EA7972004DBA18 /* as_parser.cpp in Sources */,
 				E82E674D18EA7972004DBA18 /* as_restore.cpp in Sources */,
 				E82E674E18EA7972004DBA18 /* as_scriptcode.cpp in Sources */,
+				E8C7D7BE22DB2A4400F78763 /* ConsoleCommandCandidate.cpp in Sources */,
 				E82E674F18EA7972004DBA18 /* as_scriptengine.cpp in Sources */,
 				E82E675018EA7972004DBA18 /* as_scriptfunction.cpp in Sources */,
 				E82E675118EA7972004DBA18 /* as_scriptnode.cpp in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		E8C7D7AF22DA34F500F78763 /* ConsoleScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */; };
 		E8C7D7B122DA35F000F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */; };
 		E8C7D7B422DAF5B500F78763 /* ConsoleCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */; };
+		E8C7D7BA22DB220300F78763 /* ConfigConsoleResponder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -768,6 +769,8 @@
 		E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleHelper.cpp; sourceTree = "<group>"; };
 		E8C7D7B222DAF5B400F78763 /* ConsoleCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleCommand.h; sourceTree = "<group>"; };
 		E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommand.cpp; sourceTree = "<group>"; };
+		E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConfigConsoleResponder.cpp; sourceTree = "<group>"; };
+		E8C7D7B922DB220300F78763 /* ConfigConsoleResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigConsoleResponder.h; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1507,6 +1510,8 @@
 		E8CF039D178EDDBF000683D4 /* Gui */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */,
+				E8C7D7B922DB220300F78763 /* ConfigConsoleResponder.h */,
 				E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */,
 				E8C7D7B222DAF5B400F78763 /* ConsoleCommand.h */,
 				E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */,
@@ -2315,6 +2320,7 @@
 				E88344101E03244F000C3E39 /* FontManager.cpp in Sources */,
 				E893A3631E3E3331000654A4 /* PackageUpdateManager.cpp in Sources */,
 				E82E672318EA7954004DBA18 /* Runner.cpp in Sources */,
+				E8C7D7BA22DB220300F78763 /* ConfigConsoleResponder.cpp in Sources */,
 				E82E672418EA7954004DBA18 /* StartupScreen.cpp in Sources */,
 				E82E66ED18EA7914004DBA18 /* StartupScreenHelper.cpp in Sources */,
 			);

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		E8C7D7B422DAF5B500F78763 /* ConsoleCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */; };
 		E8C7D7BA22DB220300F78763 /* ConfigConsoleResponder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */; };
 		E8C7D7BE22DB2A4400F78763 /* ConsoleCommandCandidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */; };
+		E8C7D7C022DB3AE000F78763 /* ConsoleCommandCandidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7BF22DB3AE000F78763 /* ConsoleCommandCandidate.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -775,6 +776,7 @@
 		E8C7D7BB22DB263200F78763 /* Iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iterator.h; sourceTree = "<group>"; };
 		E8C7D7BC22DB2A4400F78763 /* ConsoleCommandCandidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleCommandCandidate.h; sourceTree = "<group>"; };
 		E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommandCandidate.cpp; sourceTree = "<group>"; };
+		E8C7D7BF22DB3AE000F78763 /* ConsoleCommandCandidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommandCandidate.cpp; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1400,6 +1402,7 @@
 		E8B6B6E617E40AF300E35523 /* ScriptBindings */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7BF22DB3AE000F78763 /* ConsoleCommandCandidate.cpp */,
 				E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */,
 				E8B6B6E717E40AF500E35523 /* MathScript.cpp */,
 				E838D42018ADDE2800EE3C53 /* StringsScript.cpp */,
@@ -2100,6 +2103,7 @@
 				E82E674A18EA7972004DBA18 /* as_objecttype.cpp in Sources */,
 				E82E674B18EA7972004DBA18 /* as_outputbuffer.cpp in Sources */,
 				E82E674C18EA7972004DBA18 /* as_parser.cpp in Sources */,
+				E8C7D7C022DB3AE000F78763 /* ConsoleCommandCandidate.cpp in Sources */,
 				E82E674D18EA7972004DBA18 /* as_restore.cpp in Sources */,
 				E82E674E18EA7972004DBA18 /* as_scriptcode.cpp in Sources */,
 				E8C7D7BE22DB2A4400F78763 /* ConsoleCommandCandidate.cpp in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -298,6 +298,9 @@
 		E89A5F201DF8759200857F65 /* ShellApi.mm in Sources */ = {isa = PBXBuildFile; fileRef = E89A5F1F1DF8759200857F65 /* ShellApi.mm */; };
 		E89BBDC31B3559CD00F53EE9 /* GLAutoExposureFilter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E89BBDC01B3559CD00F53EE9 /* GLAutoExposureFilter.cpp */; };
 		E8A2EBA01F5BE16D00E39CD9 /* GameProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8A2EB9E1F5BE16D00E39CD9 /* GameProperties.cpp */; };
+		E8C7D7AE22DA34F500F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */; };
+		E8C7D7AF22DA34F500F78763 /* ConsoleScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */; };
+		E8C7D7B122DA35F000F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -757,6 +760,11 @@
 		E8B6B74817EA12E500E35523 /* IWeaponSkin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IWeaponSkin.h; sourceTree = "<group>"; };
 		E8B8082718E05B920001013E /* CellToTriangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CellToTriangle.h; sourceTree = "<group>"; };
 		E8B93AD418559EC600BD01E1 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = lib/SDL2.framework; sourceTree = "<group>"; };
+		E8C7D7AA22DA34F400F78763 /* ConsoleHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleHelper.h; sourceTree = "<group>"; };
+		E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleHelper.cpp; sourceTree = "<group>"; };
+		E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleScreen.cpp; sourceTree = "<group>"; };
+		E8C7D7AD22DA34F500F78763 /* ConsoleScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleScreen.h; sourceTree = "<group>"; };
+		E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleHelper.cpp; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1382,6 +1390,7 @@
 		E8B6B6E617E40AF300E35523 /* ScriptBindings */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */,
 				E8B6B6E717E40AF500E35523 /* MathScript.cpp */,
 				E838D42018ADDE2800EE3C53 /* StringsScript.cpp */,
 				E8B6B6E817E40AF500E35523 /* ScriptManager.cpp */,
@@ -1495,6 +1504,10 @@
 		E8CF039D178EDDBF000683D4 /* Gui */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */,
+				E8C7D7AA22DA34F400F78763 /* ConsoleHelper.h */,
+				E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */,
+				E8C7D7AD22DA34F500F78763 /* ConsoleScreen.h */,
 				E8F74CEC183F931F0085AA54 /* SDLMain.h */,
 				E8F74CEA183F92DA0085AA54 /* SDLmain.m */,
 				E8CF03BE178EE50E000683D4 /* Main.cpp */,
@@ -2029,6 +2042,8 @@
 				E82E67E818EA7A51004DBA18 /* host.c in Sources */,
 				E82E67E918EA7A51004DBA18 /* list.c in Sources */,
 				E82E67EA18EA7A51004DBA18 /* packet.c in Sources */,
+				E8C7D7AE22DA34F500F78763 /* ConsoleHelper.cpp in Sources */,
+				E8C7D7AF22DA34F500F78763 /* ConsoleScreen.cpp in Sources */,
 				E82E67EB18EA7A51004DBA18 /* peer.c in Sources */,
 				E8403CAB229123CF00093C3E /* PipeStream.cpp in Sources */,
 				E81012311E1D7301009955D3 /* Icon.cpp in Sources */,
@@ -2266,6 +2281,7 @@
 				E82E670718EA7954004DBA18 /* GLLongSpriteRenderer.cpp in Sources */,
 				E82E670818EA7954004DBA18 /* GLSoftLitSpriteRenderer.cpp in Sources */,
 				E82E670918EA7954004DBA18 /* GLShader.cpp in Sources */,
+				E8C7D7B122DA35F000F78763 /* ConsoleHelper.cpp in Sources */,
 				E82E670A18EA7954004DBA18 /* GLProgramUniform.cpp in Sources */,
 				E82E670B18EA7954004DBA18 /* GLProgramAttribute.cpp in Sources */,
 				E82E670C18EA7954004DBA18 /* GLProgram.cpp in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		E8C7D7AE22DA34F500F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */; };
 		E8C7D7AF22DA34F500F78763 /* ConsoleScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */; };
 		E8C7D7B122DA35F000F78763 /* ConsoleHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */; };
+		E8C7D7B422DAF5B500F78763 /* ConsoleCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -765,6 +766,8 @@
 		E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleScreen.cpp; sourceTree = "<group>"; };
 		E8C7D7AD22DA34F500F78763 /* ConsoleScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleScreen.h; sourceTree = "<group>"; };
 		E8C7D7B022DA35F000F78763 /* ConsoleHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleHelper.cpp; sourceTree = "<group>"; };
+		E8C7D7B222DAF5B400F78763 /* ConsoleCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleCommand.h; sourceTree = "<group>"; };
+		E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommand.cpp; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1504,6 +1507,8 @@
 		E8CF039D178EDDBF000683D4 /* Gui */ = {
 			isa = PBXGroup;
 			children = (
+				E8C7D7B322DAF5B400F78763 /* ConsoleCommand.cpp */,
+				E8C7D7B222DAF5B400F78763 /* ConsoleCommand.h */,
 				E8C7D7AB22DA34F400F78763 /* ConsoleHelper.cpp */,
 				E8C7D7AA22DA34F400F78763 /* ConsoleHelper.h */,
 				E8C7D7AC22DA34F400F78763 /* ConsoleScreen.cpp */,
@@ -2049,6 +2054,7 @@
 				E81012311E1D7301009955D3 /* Icon.cpp in Sources */,
 				E8A2EBA01F5BE16D00E39CD9 /* GameProperties.cpp in Sources */,
 				E82E67EC18EA7A51004DBA18 /* protocol.c in Sources */,
+				E8C7D7B422DAF5B500F78763 /* ConsoleCommand.cpp in Sources */,
 				E82E67ED18EA7A51004DBA18 /* unix.c in Sources */,
 				E82E67EE18EA7A51004DBA18 /* win32.c in Sources */,
 				E82E67EF18EA7A51004DBA18 /* pnglite.c in Sources */,

--- a/OpenSpades.xcodeproj/project.pbxproj
+++ b/OpenSpades.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		E8C7D7BA22DB220300F78763 /* ConfigConsoleResponder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7B822DB220200F78763 /* ConfigConsoleResponder.cpp */; };
 		E8C7D7BE22DB2A4400F78763 /* ConsoleCommandCandidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */; };
 		E8C7D7C022DB3AE000F78763 /* ConsoleCommandCandidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7BF22DB3AE000F78763 /* ConsoleCommandCandidate.cpp */; };
+		E8C7D7C222DB636000F78763 /* Client_Console.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8C7D7C122DB635F00F78763 /* Client_Console.cpp */; };
 		E8CB47CE1DE071CA00BF606A /* SWUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CC1DE071CA00BF606A /* SWUtils.cpp */; };
 		E8CB47D21DE07CF000BF606A /* SettingSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47CF1DE07CF000BF606A /* SettingSet.cpp */; };
 		E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8CB47D41DE084AB00BF606A /* GLSettings.cpp */; };
@@ -777,6 +778,7 @@
 		E8C7D7BC22DB2A4400F78763 /* ConsoleCommandCandidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConsoleCommandCandidate.h; sourceTree = "<group>"; };
 		E8C7D7BD22DB2A4400F78763 /* ConsoleCommandCandidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommandCandidate.cpp; sourceTree = "<group>"; };
 		E8C7D7BF22DB3AE000F78763 /* ConsoleCommandCandidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConsoleCommandCandidate.cpp; sourceTree = "<group>"; };
+		E8C7D7C122DB635F00F78763 /* Client_Console.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Client_Console.cpp; sourceTree = "<group>"; };
 		E8C92A0A18695EA500740C9F /* SWModelRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWModelRenderer.cpp; sourceTree = "<group>"; };
 		E8C92A0B18695EA500740C9F /* SWModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWModelRenderer.h; sourceTree = "<group>"; };
 		E8C92A0D186A8D3600740C9F /* CpuID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CpuID.h; sourceTree = "<group>"; };
@@ -1647,6 +1649,7 @@
 			children = (
 				E844886317D0C404005105D0 /* Local Entities */,
 				E8CF03C1178EE6D8000683D4 /* Client.cpp */,
+				E8C7D7C122DB635F00F78763 /* Client_Console.cpp */,
 				E8FE748B18CC6AA100291338 /* Client_Input.cpp */,
 				E8FE748D18CC6C2B00291338 /* Client_Update.cpp */,
 				E8FE748F18CC6CE000291338 /* Client_NetHandler.cpp */,
@@ -2280,6 +2283,7 @@
 				E82E66F018EA7954004DBA18 /* GLLensFilter.cpp in Sources */,
 				E82E66F118EA7954004DBA18 /* GLCameraBlurFilter.cpp in Sources */,
 				E82E66F218EA7954004DBA18 /* GLFogFilter.cpp in Sources */,
+				E8C7D7C222DB636000F78763 /* Client_Console.cpp in Sources */,
 				E82E66F318EA7954004DBA18 /* GLLensFlareFilter.cpp in Sources */,
 				E82E66F418EA7954004DBA18 /* GLFXAAFilter.cpp in Sources */,
 				E8CB47D61DE084AB00BF606A /* GLSettings.cpp in Sources */,

--- a/Resources/Scripts/Gui/Client/ChatSayWindow.as
+++ b/Resources/Scripts/Gui/Client/ChatSayWindow.as
@@ -20,6 +20,8 @@
 #include "FieldWithHistory.as"
 
 namespace spades {
+    // TODO: Remove cvar editing (superseded by the system console) after 0.1.4
+
     /** Shows cvar's current value when user types something like "/cg_foobar" */
     class CommandFieldConfigValueView : spades::ui::UIElement {
         string[] @configNames;
@@ -270,6 +272,9 @@ namespace spades {
                     ui.helper.SayTeam(field.Text);
                 else
                     ui.helper.SayGlobal(field.Text);
+            } else {
+                ui.helper.AlertWarning(_Tr(
+                    "Client", "cvar editing via chat window is being phased out (see issue #842)"));
             }
             Close();
         }

--- a/Resources/Scripts/Gui/Client/ChatSayWindow.as
+++ b/Resources/Scripts/Gui/Client/ChatSayWindow.as
@@ -20,15 +20,6 @@
 #include "FieldWithHistory.as"
 
 namespace spades {
-
-    uint StringCommonPrefixLength(string a, string b) {
-        for (uint i = 0, ln = Min(a.length, b.length); i < ln; i++) {
-            if (ToLower(a[i]) != ToLower(b[i]))
-                return i;
-        }
-        return Min(a.length, b.length);
-    }
-
     /** Shows cvar's current value when user types something like "/cg_foobar" */
     class CommandFieldConfigValueView : spades::ui::UIElement {
         string[] @configNames;

--- a/Resources/Scripts/Gui/Client/FieldWithHistory.as
+++ b/Resources/Scripts/Gui/Client/FieldWithHistory.as
@@ -95,6 +95,12 @@ namespace spades {
             currentHistoryIndex = cmdhistory.length - 1;
         }
 
+        void Clear() {
+            currentHistoryIndex = cmdhistory.length;
+            this.Text = "";
+            OverwriteItem();
+        }
+
         void Cancelled() { OverwriteItem(); }
     };
 

--- a/Resources/Scripts/Gui/Console/ConsoleCommandField.as
+++ b/Resources/Scripts/Gui/Console/ConsoleCommandField.as
@@ -111,6 +111,11 @@ namespace spades {
             }
         }
 
+        void Clear() {
+            FieldWithHistory::Clear();
+            OnChanged();
+        }
+
         void KeyDown(string key) {
             if (key == "Tab") {
                 // Find the command name part

--- a/Resources/Scripts/Gui/Console/ConsoleCommandField.as
+++ b/Resources/Scripts/Gui/Console/ConsoleCommandField.as
@@ -1,0 +1,151 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include "../Client/FieldWithHistory.as"
+
+namespace spades {
+
+    uint StringCommonPrefixLength(string a, string b) {
+        for (uint i = 0, ln = Min(a.length, b.length); i < ln; i++) {
+            if (ToLower(a[i]) != ToLower(b[i]))
+                return i;
+        }
+        return Min(a.length, b.length);
+    }
+
+    /** Displys console command candidates. */
+    class ConsoleCommandFieldCandiateView : spades::ui::UIElement {
+        ConsoleCommandCandidate[] @candidates;
+        ConsoleCommandFieldCandiateView(spades::ui::UIManager @manager,
+                                        ConsoleCommandCandidate[] @candidates) {
+            super(manager);
+            @this.candidates = candidates;
+        }
+        void Render() {
+            float maxNameLen = 0.f;
+            float maxDescLen = 20.f;
+            Font @font = this.Font;
+            Renderer @renderer = this.Manager.Renderer;
+            float rowHeight = 25.f;
+
+            for (uint i = 0, len = candidates.length; i < len; i++) {
+                maxNameLen = Max(maxNameLen, font.Measure(candidates[i].Name).x);
+                maxDescLen = Max(maxDescLen, font.Measure(candidates[i].Description).x);
+            }
+            Vector2 pos = this.ScreenPosition;
+
+            renderer.ColorNP = Vector4(0.f, 0.f, 0.f, 0.5f);
+            renderer.DrawImage(null, AABB2(pos.x, pos.y, maxNameLen + maxDescLen + 20.f,
+                                           float(candidates.length) * rowHeight + 10.f));
+
+            for (uint i = 0, len = candidates.length; i < len; i++) {
+                font.DrawShadow(candidates[i].Name, pos + Vector2(5.f, 8.f + float(i) * rowHeight),
+                                1.f, Vector4(1, 1, 1, 0.7), Vector4(0, 0, 0, 0.3f));
+                font.DrawShadow(candidates[i].Description,
+                                pos + Vector2(15.f + maxNameLen, 8.f + float(i) * rowHeight), 1.f,
+                                Vector4(1, 1, 1, 1), Vector4(0, 0, 0, 0.4f));
+            }
+        }
+    }
+
+    /** A `Field` with a command name autocompletion feature. */
+    class ConsoleCommandField : FieldWithHistory {
+        private ConsoleCommandFieldCandiateView @valueView;
+        private ConsoleHelper @helper;
+
+        ConsoleCommandField(spades::ui::UIManager @manager,
+                            array<spades::ui::CommandHistoryItem @> @history,
+                            ConsoleHelper @helper) {
+            super(manager, history);
+
+            @this.helper = helper;
+        }
+
+        void OnChanged() {
+            FieldWithHistory::OnChanged();
+
+            if (valueView !is null) {
+                @valueView.Parent = null;
+            }
+
+            // Find the command name part
+            int whitespace = Text.findFirst(" ");
+            if (whitespace < 0) {
+                whitespace = int(Text.length);
+            }
+
+            if (whitespace > 0) {
+                string input = Text.substr(0, whitespace);
+                ConsoleCommandCandidateIterator @it = helper.AutocompleteCommandName(input);
+                ConsoleCommandCandidate[] @candidates = {};
+
+                for (uint i = 0; i < 16; ++i) {
+                    if (!it.MoveNext()) {
+                        break;
+                    }
+
+                    candidates.insertLast(it.Current);
+                }
+
+                if (candidates.length > 0) {
+                    @valueView = ConsoleCommandFieldCandiateView(this.Manager, candidates);
+                    valueView.Bounds = AABB2(0.f, Size.y + 10.f, 0.f, 0.f);
+                    @valueView.Parent = this;
+                }
+            }
+        }
+
+        void KeyDown(string key) {
+            if (key == "Tab") {
+                // Find the command name part
+                int whitespace = Text.findFirst(" ");
+                if (whitespace < 0) {
+                    whitespace = int(Text.length);
+                }
+
+                if (SelectionLength == 0 && SelectionStart <= whitespace) {
+                    // Command name auto completion
+                    string input = Text.substr(0, whitespace);
+                    ConsoleCommandCandidateIterator @it = helper.AutocompleteCommandName(input);
+                    string commonPart;
+                    bool foundOne = false;
+                    while (it.MoveNext()) {
+                        string name = it.Current.Name;
+                        if (StringCommonPrefixLength(input, name) == input.length) {
+                            if (!foundOne) {
+                                commonPart = name;
+                                foundOne = true;
+                            }
+
+                            uint commonLen = StringCommonPrefixLength(commonPart, name);
+                            commonPart = commonPart.substr(0, commonLen);
+                        }
+                    }
+
+                    if (commonPart.length > input.length) {
+                        Text = commonPart + Text.substr(whitespace);
+                        Select(commonPart.length, 0);
+                    }
+                }
+            } else {
+                FieldWithHistory::KeyDown(key);
+            }
+        }
+    }
+}

--- a/Resources/Scripts/Gui/Console/ConsoleUI.as
+++ b/Resources/Scripts/Gui/Console/ConsoleUI.as
@@ -53,7 +53,13 @@ namespace spades {
 
         void WheelEvent(float x, float y) { manager.WheelEvent(x, y); }
 
-        void KeyEvent(string key, bool down) { manager.KeyEvent(key, down); }
+        void KeyEvent(string key, bool down) {
+            if (key == "Escape") {
+                active = false;
+                return;
+            }
+            manager.KeyEvent(key, down);
+        }
 
         void TextInputEvent(string text) { manager.TextInputEvent(text); }
 

--- a/Resources/Scripts/Gui/Console/ConsoleUI.as
+++ b/Resources/Scripts/Gui/Console/ConsoleUI.as
@@ -1,0 +1,81 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include "../UIFramework/UIFramework.as"
+#include "ConsoleWindow.as"
+
+namespace spades {
+    ConsoleUI @CreateConsoleUI(Renderer @renderer, AudioDevice @audioDevice,
+                               FontManager @fontManager, ConsoleHelper @helper) {
+        return ConsoleUI(renderer, audioDevice, fontManager, helper);
+    }
+
+    /**
+     * Implements the system console window.
+     *
+     * `ConsoleUI` is overlaid on the normal rendering. Normally, it's invisible,
+     * but it becomes visible when invoked by a hotkey. When it's visible, it
+     * also intercepts all inputs.
+     */
+    class ConsoleUI {
+        private spades::ui::UIManager @manager;
+        private bool active = false;
+
+        private ConsoleWindow @console;
+
+        ConsoleUI(Renderer @renderer, AudioDevice @audioDevice, FontManager @fontManager,
+                  ConsoleHelper @helper) {
+            @manager = spades::ui::UIManager(renderer, audioDevice);
+            @manager.RootElement.Font = fontManager.GuiFont;
+
+            @console = ConsoleWindow(helper, manager);
+            console.Bounds = manager.RootElement.Bounds;
+            manager.RootElement.AddChild(console);
+        }
+
+        void MouseEvent(float x, float y) { manager.MouseEvent(x, y); }
+
+        void WheelEvent(float x, float y) { manager.WheelEvent(x, y); }
+
+        void KeyEvent(string key, bool down) { manager.KeyEvent(key, down); }
+
+        void TextInputEvent(string text) { manager.TextInputEvent(text); }
+
+        void TextEditingEvent(string text, int start, int len) {
+            manager.TextEditingEvent(text, start, len);
+        }
+
+        bool AcceptsTextInput() { return manager.AcceptsTextInput; }
+
+        AABB2 GetTextInputRect() { return manager.TextInputRect; }
+
+        void RunFrame(float dt) {
+            manager.RunFrame(dt);
+            if (active) {
+                manager.Render();
+            }
+        }
+
+        void Closing() {}
+
+        bool ShouldInterceptInput() { return active; }
+
+        void ToggleConsole() { active = !active; }
+    }
+}

--- a/Resources/Scripts/Gui/Console/ConsoleUI.as
+++ b/Resources/Scripts/Gui/Console/ConsoleUI.as
@@ -82,6 +82,13 @@ namespace spades {
 
         bool ShouldInterceptInput() { return active; }
 
-        void ToggleConsole() { active = !active; }
+        void ToggleConsole() {
+            active = !active;
+            if (active) {
+                console.FocusField();
+            }
+        }
+
+        void AddLine(string line) { console.AddLine(line); }
     }
 }

--- a/Resources/Scripts/Gui/Console/ConsoleWindow.as
+++ b/Resources/Scripts/Gui/Console/ConsoleWindow.as
@@ -79,8 +79,7 @@ namespace spades {
                     return;
                 }
                 field.CommandSent();
-                // TODO: Execute the command
-                viewer.AddLine("TODO: " + field.Text, true);
+                helper.ExecCommand(field.Text);
                 field.Text = "";
             }
         }

--- a/Resources/Scripts/Gui/Console/ConsoleWindow.as
+++ b/Resources/Scripts/Gui/Console/ConsoleWindow.as
@@ -18,7 +18,7 @@
 
  */
 #include "../UIFramework/UIFramework.as"
-#include "../Client/FieldWithHistory.as"
+#include "ConsoleCommandField.as"
 
 namespace spades {
     class ConsoleWindow : spades::ui::UIElement {
@@ -52,7 +52,7 @@ namespace spades {
             }
 
             {
-                @field = FieldWithHistory(Manager, this.history);
+                @field = ConsoleCommandField(Manager, this.history, helper);
                 field.Bounds = AABB2(10.0, height - 35.0, screenWidth - 20.0, 30.f);
                 field.Placeholder = _Tr("Console", "Command");
                 @field.Changed = spades::ui::EventHandler(this.OnFieldChanged);

--- a/Resources/Scripts/Gui/Console/ConsoleWindow.as
+++ b/Resources/Scripts/Gui/Console/ConsoleWindow.as
@@ -80,7 +80,7 @@ namespace spades {
                 }
                 field.CommandSent();
                 helper.ExecCommand(field.Text);
-                field.Text = "";
+                field.Clear();
             }
         }
     }

--- a/Resources/Scripts/Gui/Console/ConsoleWindow.as
+++ b/Resources/Scripts/Gui/Console/ConsoleWindow.as
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+#include "../UIFramework/UIFramework.as"
+
+namespace spades {
+    class ConsoleWindow : spades::ui::UIElement {
+        private ConsoleHelper @helper;
+
+        ConsoleWindow(ConsoleHelper @helper, spades::ui::UIManager @manager) {
+            super(manager);
+            @this.helper = helper;
+
+            float height = floor(Manager.Renderer.ScreenHeight * 0.2);
+
+            {
+                spades::ui::Label label(Manager);
+                label.BackgroundColor = Vector4(0, 0, 0, 0.8f);
+                label.Bounds = AABB2(0.f, 0.f, Manager.Renderer.ScreenWidth, height);
+                AddChild(label);
+            }
+            {
+                spades::ui::Label label(Manager);
+                label.BackgroundColor = Vector4(0, 0, 0, 0.5f);
+                label.Bounds = AABB2(0.f, height, Manager.Renderer.ScreenWidth,
+                                     Manager.Renderer.ScreenHeight - height);
+                AddChild(label);
+            }
+            // TODO
+        }
+    }
+} // namespace spades

--- a/Resources/Scripts/Gui/MainScreen/MainScreenUI.as
+++ b/Resources/Scripts/Gui/MainScreen/MainScreenUI.as
@@ -159,9 +159,12 @@ namespace spades {
             manager.RunFrame(dt);
             manager.Render();
 
+            time += Min(dt, 0.05f);
+        }
+
+        void RunFrameLate(float dt) {
             renderer.FrameDone();
             renderer.Flip();
-            time += Min(dt, 0.05f);
         }
 
         void Closing() { shouldExit = true; }

--- a/Resources/Scripts/Gui/StartupScreen/StartupScreenUI.as
+++ b/Resources/Scripts/Gui/StartupScreen/StartupScreenUI.as
@@ -98,7 +98,9 @@ namespace spades {
 
             manager.RunFrame(dt);
             manager.Render();
+        }
 
+        void RunFrameLate(float dt) {
             renderer.FrameDone();
             renderer.Flip();
         }

--- a/Resources/Scripts/Gui/UIFramework/ListView.as
+++ b/Resources/Scripts/Gui/UIFramework/ListView.as
@@ -158,9 +158,6 @@ namespace spades {
             ListViewModel @Model {
                 get final { return model; }
                 set {
-                    if (model is value) {
-                        return;
-                    }
                     UnloadAll();
                     @model = value;
                     Layout();

--- a/Resources/Scripts/Reference/API/Renderer.as
+++ b/Resources/Scripts/Reference/API/Renderer.as
@@ -43,6 +43,13 @@ namespace spades {
          */
         Model @RegisterModel(const string @path) {}
 
+        /**
+         * Clear the cache of models and images loaded via `RegisterModel`
+         * and `RegisterImage`. This method is merely a hint - the
+         * implementation may partially or completely ignore the request.
+         */
+        void ClearCache() {}
+
         /** Creates an image from the specified bitmap. */
         Image @CreateImage(Bitmap @bitmap) {}
 

--- a/Sources/AngelScript/addons/scriptarray.cpp
+++ b/Sources/AngelScript/addons/scriptarray.cpp
@@ -664,7 +664,7 @@ void CScriptArray::RemoveRange(asUINT start, asUINT count)
 	// Compact the elements
 	// As objects in arrays of objects are not stored inline, it is safe to use memmove here
 	// since we're just copying the pointers to objects and not the actual objects.
-	memmove(buffer->data + start*elementSize, buffer->data + (start + count)*elementSize, count*elementSize);
+	memcpy(buffer->data + start*elementSize, buffer->data + (start + count)*elementSize, (buffer->numElements - count)*elementSize);
 	buffer->numElements -= count;
 }
 

--- a/Sources/Audio/ALDevice.cpp
+++ b/Sources/Audio/ALDevice.cpp
@@ -767,6 +767,8 @@ namespace spades {
 		ALDevice::~ALDevice() {
 			SPADES_MARK_FUNCTION();
 
+			// TODO: Fix memory leak!
+
 			delete d;
 		}
 		ALAudioChunk *ALDevice::CreateChunk(const char *name) {
@@ -796,6 +798,15 @@ namespace spades {
 			}
 			it->second->AddRef();
 			return it->second;
+		}
+
+		void ALDevice::ClearCache() {
+			SPADES_MARK_FUNCTION();
+
+			for (auto &chunk: chunks) {
+				chunk.second->Release();
+			}
+			chunks.clear();
 		}
 
 		void ALDevice::Play(client::IAudioChunk *chunk, const spades::Vector3 &origin,

--- a/Sources/Audio/ALDevice.h
+++ b/Sources/Audio/ALDevice.h
@@ -45,6 +45,8 @@ namespace spades {
 
 			client::IAudioChunk *RegisterSound(const char *name) override;
 
+			void ClearCache() override;
+
 			void SetGameMap(client::GameMap *) override;
 
 			void Play(client::IAudioChunk *, const Vector3 &origin,

--- a/Sources/Audio/YsrDevice.cpp
+++ b/Sources/Audio/YsrDevice.cpp
@@ -443,6 +443,15 @@ namespace spades {
 			return it->second;
 		}
 
+		void YsrDevice::ClearCache() {
+			SPADES_MARK_FUNCTION();
+
+			for (auto &chunk: chunks) {
+				chunk.second->Release();
+			}
+			chunks.clear();
+		}
+
 		void YsrDevice::SetGameMap(client::GameMap *gameMap) {
 			SPADES_MARK_FUNCTION();
 			auto *old = this->gameMap;

--- a/Sources/Audio/YsrDevice.h
+++ b/Sources/Audio/YsrDevice.h
@@ -62,6 +62,8 @@ namespace spades {
 
 			client::IAudioChunk *RegisterSound(const char *name) override;
 
+			void ClearCache() override;
+
 			void SetGameMap(client::GameMap *) override;
 
 			void Play(client::IAudioChunk *, const Vector3 &origin,

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -600,6 +600,7 @@ namespace spades {
 				std::string msg;
 				msg = _Tr("Client", "Map saved: {0}", name);
 				ShowAlert(msg, AlertType::Notice);
+				SPLog("Map saved: %s", name.c_str());
 			} catch (const Exception &ex) {
 				std::string msg;
 				msg = _Tr("Client", "Saving map failed: ");

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -65,7 +65,7 @@ SPADES_SETTING(cg_playerName);
 
 namespace spades {
 	namespace client {
-        
+
 		Client::Client(IRenderer *r, IAudioDevice *audioDev, const ServerAddress &host,
 		               FontManager *fontManager)
 		    : playerName(cg_playerName.operator std::string().substr(0, 15)),
@@ -471,14 +471,19 @@ namespace spades {
 			if (scriptedUI->WantsClientToBeClosed())
 				readyToClose = true;
 
-			// Well done!
-			renderer->FrameDone();
-			renderer->Flip();
-
 			// reset all "delayed actions" (in case we forget to reset these)
 			hasDelayedReload = false;
 
 			time += dt;
+		}
+
+
+		void Client::RunFrameLate(float dt) {
+			SPADES_MARK_FUNCTION();
+
+			// Well done!
+			renderer->FrameDone();
+			renderer->Flip();
 		}
 
 		bool Client::IsLimboViewActive() {

--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -66,19 +66,16 @@ SPADES_SETTING(cg_playerName);
 namespace spades {
 	namespace client {
 
-		Client::Client(IRenderer *r, IAudioDevice *audioDev, const ServerAddress &host,
-		               FontManager *fontManager)
+		Client::Client(Handle<IRenderer> r, Handle<IAudioDevice> audioDev,
+		               const ServerAddress &host, Handle<FontManager> fontManager)
 		    : playerName(cg_playerName.operator std::string().substr(0, 15)),
 		      logStream(nullptr),
 		      hostname(host),
 		      renderer(r),
 		      audioDevice(audioDev),
 
-
 		      time(0.f),
 		      readyToClose(false),
-
-
 
 		      worldSubFrame(0.f),
 		      frameToRendererInit(5),
@@ -477,7 +474,6 @@ namespace spades {
 			time += dt;
 		}
 
-
 		void Client::RunFrameLate(float dt) {
 			SPADES_MARK_FUNCTION();
 
@@ -719,8 +715,8 @@ namespace spades {
 
 			bool localPlayerIsSpectator = localPlayer.IsSpectator();
 
-			int nextId = FollowsNonLocalPlayer(GetCameraMode()) ? followedPlayerId :
-				world->GetLocalPlayerIndex();
+			int nextId = FollowsNonLocalPlayer(GetCameraMode()) ? followedPlayerId
+			                                                    : world->GetLocalPlayerIndex();
 			do {
 				reverse ? --nextId : ++nextId;
 
@@ -759,5 +755,5 @@ namespace spades {
 				followCameraState.enabled = true;
 			}
 		}
-	}
-}
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -412,6 +412,9 @@ namespace spades {
 			bool AcceptsTextInput() override;
 			AABB2 GetTextInputRect() override;
 			bool NeedsAbsoluteMouseCoordinate() override;
+			bool ExecCommand(const Handle<gui::ConsoleCommand> &) override;
+			Handle<gui::ConsoleCommandCandidateIterator>
+			AutocompleteCommandName(const std::string &name) override;
 
 			void SetWorld(World *);
 			World *GetWorld() const { return world.get(); }

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -98,7 +98,7 @@ namespace spades {
 
 			FPSCounter fpsCounter;
 			FPSCounter upsCounter;
-			
+
 			std::unique_ptr<NetClient> net;
 			std::string playerName;
 			std::unique_ptr<IStream> logStream;
@@ -400,6 +400,7 @@ namespace spades {
 			Client(IRenderer *, IAudioDevice *, const ServerAddress &host, FontManager *);
 
 			void RunFrame(float dt) override;
+			void RunFrameLate(float dt) override;
 
 			void Closing() override;
 			void MouseEvent(float x, float y) override;

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "ClientCameraMode.h"
 #include "ILocalEntity.h"
 #include "IRenderer.h"
 #include "IWorldListener.h"
@@ -35,7 +36,6 @@
 #include <Core/ServerAddress.h>
 #include <Core/Stopwatch.h>
 #include <Gui/View.h>
-#include "ClientCameraMode.h"
 
 namespace spades {
 	class IStream;
@@ -222,10 +222,10 @@ namespace spades {
 			/** The state of the free floating camera used for spectating. */
 			struct {
 				/** The temporally smoothed position (I guess). */
-				Vector3 position {0.0f, 0.0f, 0.0f};
+				Vector3 position{0.0f, 0.0f, 0.0f};
 
 				/** The temporally smoothed velocity (I guess). */
-				Vector3 velocity {0.0f, 0.0f, 0.0f};
+				Vector3 velocity{0.0f, 0.0f, 0.0f};
 			} freeCameraState;
 
 			/**
@@ -397,7 +397,8 @@ namespace spades {
 			~Client();
 
 		public:
-			Client(IRenderer *, IAudioDevice *, const ServerAddress &host, FontManager *);
+			Client(Handle<IRenderer>, Handle<IAudioDevice>, const ServerAddress &host,
+			       Handle<FontManager>);
 
 			void RunFrame(float dt) override;
 			void RunFrameLate(float dt) override;
@@ -458,7 +459,7 @@ namespace spades {
 
 			/** @deprecated use BulletHitPlayer */
 			void PlayerHitBlockWithSpade(Player *, Vector3 hitPos, IntVector3 blockPos,
-			                                     IntVector3 normal) override;
+			                             IntVector3 normal) override;
 			void PlayerKilledPlayer(Player *killer, Player *victim, KillType) override;
 
 			void BulletHitPlayer(Player *hurtPlayer, HitType, Vector3 hitPos, Player *by) override;
@@ -476,5 +477,5 @@ namespace spades {
 			void LocalPlayerHurt(HurtType type, bool sourceGiven, Vector3 source) override;
 			void LocalPlayerBuildError(BuildFailureReason reason) override;
 		};
-	}
-}
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/Client_Console.cpp
+++ b/Sources/Client/Client_Console.cpp
@@ -1,0 +1,51 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Client.h"
+
+#include <Gui/ConsoleCommand.h>
+
+namespace spades {
+	namespace client {
+		namespace {
+			constexpr const char *CMD_SAVEMAP = "savemap";
+
+			std::map<std::string, std::string> const g_clientCommands{
+			  {CMD_SAVEMAP, ": Save the current state of the map to the disk"},
+			};
+		} // namespace
+
+		bool Client::ExecCommand(const Handle<gui::ConsoleCommand> &cmd) {
+			if (cmd->GetName() == CMD_SAVEMAP) {
+				if (cmd->GetNumArguments() != 0) {
+					SPLog("Usage: %s (no arguments)", CMD_SAVEMAP);
+					return true;
+				}
+				TakeMapShot();
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		Handle<gui::ConsoleCommandCandidateIterator>
+		Client::AutocompleteCommandName(const std::string &name) {
+			return gui::MakeCandidates(g_clientCommands, name);
+		}
+	} // namespace client
+} // namespace spades

--- a/Sources/Client/IAudioDevice.h
+++ b/Sources/Client/IAudioDevice.h
@@ -46,6 +46,13 @@ namespace spades {
 
 			virtual IAudioChunk *RegisterSound(const char *name) = 0;
 
+			/**
+			 * Clear the cache of chunks loaded via `RegisterSound`. This method
+			 * is merely a hint - the implementation may partially or completely
+			 * ignore the request.
+			 */
+			virtual void ClearCache() {}
+
 			virtual void SetGameMap(GameMap *) = 0;
 
 			virtual void Play(IAudioChunk *, const Vector3 &origin, const AudioParam &) = 0;

--- a/Sources/Client/IRenderer.h
+++ b/Sources/Client/IRenderer.h
@@ -98,6 +98,13 @@ namespace spades {
 			virtual IImage *RegisterImage(const char *filename) = 0;
 			virtual IModel *RegisterModel(const char *filename) = 0;
 
+			/**
+			 * Clear the cache of models and images loaded via `RegisterModel`
+			 * and `RegisterImage`. This method is merely a hint - the
+			 * implementation may partially or completely ignore the request.
+			 */
+			virtual void ClearCache() {}
+
 			virtual IImage *CreateImage(Bitmap *) = 0;
 			virtual IModel *CreateModel(VoxelModel *) = 0;
 

--- a/Sources/Core/Debug.cpp
+++ b/Sources/Core/Debug.cpp
@@ -160,7 +160,7 @@ namespace spades {
 			void Push(std::string &&line) {
 				lines.push_back(std::move(line));
 
-				if (lines.size() > 100) {
+				if (lines.size() > 1000) {
 					++overflow;
 					lines.pop_front();
 				}

--- a/Sources/Core/Debug.cpp
+++ b/Sources/Core/Debug.cpp
@@ -20,15 +20,17 @@
 
 #include <cstdarg>
 #include <ctime>
+#include <deque>
 #include <map>
 #include <string>
 
-#include <Core/Debug.h>
-#include <Imports/SDL.h>
 #include "Debug.h"
 #include "FileManager.h"
 #include "IStream.h"
 #include "Math.h"
+#include "Strings.h"
+#include <Core/Debug.h>
+#include <Imports/SDL.h>
 
 #define SPADES_USE_TLS 1
 
@@ -148,9 +150,49 @@ namespace spades {
 			}
 			return message;
 		}
-	}
+	} // namespace reflection
 
 #pragma mark -
+
+	namespace {
+		class BoundedLogBuffer {
+		public:
+			void Push(std::string &&line) {
+				lines.push_back(std::move(line));
+
+				if (lines.size() > 100) {
+					++overflow;
+					lines.pop_front();
+				}
+			}
+
+			void MergeFrom(BoundedLogBuffer &&other) {
+				for (auto &line : other.lines) {
+					Push(std::move(line));
+				}
+				other.lines.clear();
+			}
+
+			/** Flush log lines. Not safe to call `Push` while in progress. */
+			template <class C> void Flush(C &&cb) {
+				if (overflow > 0) {
+					cb(Format("[{} log lines were lost]", overflow));
+					overflow = 0;
+				}
+				for (auto &line : lines) {
+					cb(std::move(line));
+				}
+				lines.clear();
+			}
+
+		private:
+			std::deque<std::string> lines;
+			std::size_t overflow = 0;
+		};
+
+		/** Stores log lines to be displayed in the internal console. */
+		BoundedLogBuffer g_consoleLogBuffer;
+	} // namespace
 
 	static IStream *logStream = NULL;
 	static bool attemptedToInitializeLog = false;
@@ -163,6 +205,24 @@ namespace spades {
 		logStream->Write(accumlatedLog);
 		accumlatedLog.clear();
 	}
+
+	void GetBufferedLogLines(stmp::dyn_function<void(std::string)> &&cb) {
+		BoundedLogBuffer tmp;
+
+		// Swap log buffers because `Push` is not safe to call while
+		// `Flush` is in progress
+		std::swap(tmp, g_consoleLogBuffer);
+
+		tmp.Flush(cb);
+
+		// Swap them back
+		std::swap(tmp, g_consoleLogBuffer);
+
+		// Process log lines recoded while we were doing this
+		g_consoleLogBuffer.MergeFrom(std::move(tmp));
+	}
+
+	// TODO: What happened to thread-safety here
 
 	void LogMessage(const char *file, int line, const char *format, ...) {
 		char buf[4096];
@@ -182,15 +242,18 @@ namespace spades {
 
 		// lm: using \r\n instead of \n so that some shitty windows editors (notepad f.e.) can parse
 		// this file aswell (all decent editors should ignore it anyway)
-		snprintf(buf, sizeof(buf), "%04d/%02d/%02d %02d:%02d:%02d [%s:%d] %s\r\n", tm.tm_year + 1900,
-		        tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, fn.c_str(), line,
-		        str.c_str());
+		snprintf(buf, sizeof(buf), "%04d/%02d/%02d %02d:%02d:%02d [%s:%d] %s\r\n",
+		         tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec,
+		         fn.c_str(), line, str.c_str());
 		buf[sizeof(buf) - 1] = 0;
 
-		std::string outStr = EscapeControlCharacters(buf);
+		// Log messages are outputted to three destinations.
 
+		// (1) stdout
+		std::string outStr = EscapeControlCharacters(buf);
 		printf("%s", outStr.c_str());
 
+		// (2) The log file a.k.a. `SystemMessages.log`
 		if (logStream || !attemptedToInitializeLog) {
 
 			if (attemptedToInitializeLog) {
@@ -199,5 +262,9 @@ namespace spades {
 			} else
 				accumlatedLog += buf;
 		}
+
+		// (3) The internal console window
+		std::string consoleLogLine{buf, strlen(buf) - 2}; // Remove `\r\n`
+		g_consoleLogBuffer.Push(std::move(consoleLogLine));
 	}
-}
+} // namespace spades

--- a/Sources/Core/Debug.h
+++ b/Sources/Core/Debug.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "Exception.h"
+#include "TMPUtils.h"
 
 namespace spades {
 	namespace reflection {
@@ -79,7 +80,7 @@ namespace spades {
 		};
 
 		std::string BacktraceRecordToString(const BacktraceRecord &);
-	}
+	} // namespace reflection
 	void StartLog();
 
 	void LogMessage(const char *file, int line, const char *format, ...)
@@ -87,7 +88,14 @@ namespace spades {
 	  __attribute__((format(printf, 3, 4)))
 #endif
 	  ;
-}
+
+	/**
+	 * Read and remove log lines in a buffer.
+	 *
+	 * This function is used by the internal system console.
+	 */
+	void GetBufferedLogLines(stmp::dyn_function<void(std::string)> &&cb);
+} // namespace spades
 
 #ifdef _MSC_VER
 #define __PRETTY_FUNCTION__ __FUNCDNAME__

--- a/Sources/Core/Iterator.h
+++ b/Sources/Core/Iterator.h
@@ -1,0 +1,53 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <Core/Debug.h>
+#include <Core/RefCountedObject.h>
+
+namespace spades {
+	/**
+	 * Represents an iterator object.
+	 *
+	 * At the initial state, it does not point any element. `MoveNext` must be
+	 * called first to move the iterator to the first element.
+	 */
+	template <class T> class Iterator : public RefCountedObject {
+	public:
+		/**
+		 * Get the current item.
+		 */
+		virtual T GetCurrent() = 0;
+
+		/**
+		 * Advance the iterator.
+		 *
+		 * @return `true` if the iterator was successfully advanced to the next
+		 *         element. `false` if it reached the end of the sequence.
+		 */
+		virtual bool MoveNext() = 0;
+	};
+
+	/** Represents an iterator that produces no elements. */
+	template <class T> class EmptyIterator final : public Iterator<T> {
+	public:
+		T GetCurrent() override { SPUnreachable(); }
+		bool MoveNext() override { return false; }
+	};
+} // namespace spades

--- a/Sources/Core/Settings.h
+++ b/Sources/Core/Settings.h
@@ -122,6 +122,7 @@ namespace spades {
 
 		void Load();
 		void Flush();
+		/** Return a list of all config variables, sorted by name. */
 		std::vector<std::string> GetAllItemNames();
 	};
 	/*

--- a/Sources/Core/TMPUtils.h
+++ b/Sources/Core/TMPUtils.h
@@ -190,4 +190,35 @@ namespace stmp {
 
 		inline T *release() { return take().release(); }
 	};
-}
+
+	/** `dyn Fn` */
+	template <class T> class dyn_function {
+	public:
+		static_assert(sizeof(T) != sizeof(T), "bad usage");
+	};
+
+	template <class R, class... Args> class dyn_function<R(Args...)> {
+	public:
+		virtual R operator()(Args &&... args) const = 0;
+	};
+
+	/** `impl Fn` */
+	template <class T, class Fn> class function {
+	public:
+		static_assert(sizeof(T) != sizeof(T), "bad usage");
+	};
+
+	template <class T, class R, class... Args>
+	class function<T, R(Args...)> : public dyn_function<R(Args...)> {
+	public:
+		function(T &&inner) : inner{inner} {}
+		R operator()(Args &&... args) const override { return inner(std::forward<Args>(args)...); }
+
+	private:
+		T inner;
+	};
+
+	template <class Fn, class T> function<T, Fn> make_fn(T &&inner) {
+		return function<T, Fn>(std::move(inner));
+	}
+} // namespace stmp

--- a/Sources/Draw/GLImageManager.cpp
+++ b/Sources/Draw/GLImageManager.cpp
@@ -19,13 +19,13 @@
  */
 
 #include "GLImageManager.h"
+#include "GLImage.h"
+#include "GLRenderer.h"
+#include "IGLDevice.h"
 #include <Core/Bitmap.h>
 #include <Core/Debug.h>
 #include <Core/FileManager.h>
 #include <Core/IStream.h>
-#include "GLImage.h"
-#include "GLRenderer.h"
-#include "IGLDevice.h"
 
 namespace spades {
 	namespace draw {
@@ -102,5 +102,7 @@ namespace spades {
 				}
 			}
 		}
-	}
-}
+
+		void GLImageManager::ClearCache() { images.clear(); }
+	} // namespace draw
+} // namespace spades

--- a/Sources/Draw/GLImageManager.h
+++ b/Sources/Draw/GLImageManager.h
@@ -45,6 +45,8 @@ namespace spades {
 			GLImage *GetWhiteImage();
 
 			void DrawAllImages(GLRenderer *);
+
+			void ClearCache();
 		};
-	}
-}
+	} // namespace draw
+} // namespace spades

--- a/Sources/Draw/GLModelManager.cpp
+++ b/Sources/Draw/GLModelManager.cpp
@@ -66,5 +66,7 @@ namespace spades {
 
 			return static_cast<GLModel *>(renderer->CreateModelOptimized(voxelModel));
 		}
+
+		void GLModelManager::ClearCache() { models.clear(); }
 	} // namespace draw
 } // namespace spades

--- a/Sources/Draw/GLModelManager.h
+++ b/Sources/Draw/GLModelManager.h
@@ -38,6 +38,8 @@ namespace spades {
 			GLModelManager(GLRenderer *);
 			~GLModelManager();
 			GLModel *RegisterModel(const char *);
+
+			void ClearCache();
 		};
-	}
-}
+	} // namespace draw
+} // namespace spades

--- a/Sources/Draw/GLRenderer.cpp
+++ b/Sources/Draw/GLRenderer.cpp
@@ -251,6 +251,12 @@ namespace spades {
 			return modelManager->RegisterModel(filename);
 		}
 
+		void GLRenderer::ClearCache() {
+			SPADES_MARK_FUNCTION();
+			modelManager->ClearCache();
+			imageManager->ClearCache();
+		}
+
 		client::IImage *GLRenderer::CreateImage(spades::Bitmap *bmp) {
 			SPADES_MARK_FUNCTION();
 			return GLImage::FromBitmap(bmp, device);

--- a/Sources/Draw/GLRenderer.h
+++ b/Sources/Draw/GLRenderer.h
@@ -153,6 +153,8 @@ namespace spades {
 			client::IImage *RegisterImage(const char *filename) override;
 			client::IModel *RegisterModel(const char *filename) override;
 
+			void ClearCache() override;
+
 			client::IImage *CreateImage(Bitmap *) override;
 			client::IModel *CreateModel(VoxelModel *) override;
 			client::IModel *CreateModelOptimized(VoxelModel *);

--- a/Sources/Draw/SWImage.cpp
+++ b/Sources/Draw/SWImage.cpp
@@ -127,5 +127,9 @@ namespace spades {
 		}
 
 		SWImage *SWImageManager::CreateImage(Bitmap *vm) { return new SWImage(vm); }
+
+		void SWImageManager::ClearCache() {
+			images.clear();
+		}
 	}
 }

--- a/Sources/Draw/SWImage.h
+++ b/Sources/Draw/SWImage.h
@@ -69,6 +69,8 @@ namespace spades {
 
 			SWImage *RegisterImage(const std::string &);
 			SWImage *CreateImage(Bitmap *);
+
+			void ClearCache();
 		};
 	}
 }

--- a/Sources/Draw/SWModel.cpp
+++ b/Sources/Draw/SWModel.cpp
@@ -147,5 +147,9 @@ namespace spades {
 		}
 
 		SWModel *SWModelManager::CreateModel(spades::VoxelModel *vm) { return new SWModel(vm); }
+
+		void SWModelManager::ClearCache() {
+			models.clear();
+		}
 	}
 }

--- a/Sources/Draw/SWModel.h
+++ b/Sources/Draw/SWModel.h
@@ -63,6 +63,8 @@ namespace spades {
 
 			SWModel *RegisterModel(const std::string &);
 			SWModel *CreateModel(VoxelModel *);
+
+			void ClearCache();
 		};
 	}
 }

--- a/Sources/Draw/SWRenderer.cpp
+++ b/Sources/Draw/SWRenderer.cpp
@@ -152,6 +152,13 @@ namespace spades {
 			return modelManager->RegisterModel(filename);
 		}
 
+		void SWRenderer::ClearCache() {
+			SPADES_MARK_FUNCTION();
+			EnsureValid();
+			imageManager->ClearCache();
+			modelManager->ClearCache();
+		}
+
 		client::IImage *SWRenderer::CreateImage(spades::Bitmap *bmp) {
 			SPADES_MARK_FUNCTION();
 			EnsureValid();
@@ -1186,5 +1193,5 @@ namespace spades {
 
 			flatMapRenderer->SetNeedsUpdate(x, y);
 		}
-	}
-}
+	} // namespace draw
+} // namespace spades

--- a/Sources/Draw/SWRenderer.h
+++ b/Sources/Draw/SWRenderer.h
@@ -159,6 +159,8 @@ namespace spades {
 
 			client::IImage *CreateImage(Bitmap *) override;
 			client::IModel *CreateModel(VoxelModel *) override;
+
+			void ClearCache() override;
 			/*
 			GLProgram *RegisterProgram(const std::string& name) override;
 			GLShader *RegisterShader(const std::string& name) override;

--- a/Sources/Gui/ConfigConsoleResponder.cpp
+++ b/Sources/Gui/ConfigConsoleResponder.cpp
@@ -48,11 +48,22 @@ namespace spades {
 				std::size_t i = 0;
 				ConsoleCommandCandidate current;
 
+				void SkipUnknowns() {
+					while (i < names.size()) {
+						Settings::ItemHandle cvarHandle{names[i], nullptr};
+						if (!cvarHandle.IsUnknown()) {
+							break;
+						}
+						++i;
+					}
+				}
+
 			public:
 				ConfigNameIterator(const std::string &query)
 				    : names{Settings::GetInstance()->GetAllItemNames()}, query{query} {
 					// Find the starting position
 					i = std::lower_bound(names.begin(), names.end(), query) - names.begin();
+					SkipUnknowns();
 				}
 
 				const ConsoleCommandCandidate &GetCurrent() override { return current; }
@@ -71,6 +82,7 @@ namespace spades {
 					current.description = " = \"" + EscapeQuotes(cvarHandle) + "\"";
 
 					i += 1;
+					SkipUnknowns();
 
 					return true;
 				}

--- a/Sources/Gui/ConfigConsoleResponder.cpp
+++ b/Sources/Gui/ConfigConsoleResponder.cpp
@@ -70,8 +70,6 @@ namespace spades {
 
 				bool MoveNext() override {
 					if (i >= names.size() || !StartsWith(names[i], query)) {
-						// Make sure it returns `MoveNext` indefinitely
-						i = names.size();
 						return false;
 					}
 

--- a/Sources/Gui/ConfigConsoleResponder.cpp
+++ b/Sources/Gui/ConfigConsoleResponder.cpp
@@ -1,0 +1,58 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "ConfigConsoleResponder.h"
+
+#include <Core/Debug.h>
+#include <Core/Settings.h>
+#include <Core/Strings.h>
+
+#include "ConsoleCommand.h"
+
+namespace spades {
+	namespace gui {
+		namespace {
+			std::string EscapeQuotes(std::string s) { return Replace(s, "\"", "\\\""); }
+		} // namespace
+
+		bool ConfigConsoleResponder::ExecCommand(const Handle<ConsoleCommand> &cmd) {
+			SPADES_MARK_FUNCTION();
+
+			Settings::ItemHandle cvarHandle{cmd->GetName(), nullptr};
+			if (cvarHandle.IsUnknown()) {
+				return false;
+			}
+
+			if (cmd->GetNumArguments() == 0) {
+				// Display the current value
+				SPLog("%s = \"%s\"", cmd->GetName().c_str(), EscapeQuotes(cvarHandle).c_str());
+			} else if (cmd->GetNumArguments() == 1) {
+				// Set a new value
+				const std::string &newValue = cmd->GetArgument(0);
+				SPLog("%s = \"%s\" (previously \"%s\")", cmd->GetName().c_str(),
+				      EscapeQuotes(newValue).c_str(), EscapeQuotes(cvarHandle).c_str());
+				cvarHandle = newValue;
+			} else {
+				SPLog("Invalid number of arguments (Maybe you meant something "
+				      "like 'varname \"value1 value2\"'?)");
+			}
+
+			return true;
+		}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConfigConsoleResponder.h
+++ b/Sources/Gui/ConfigConsoleResponder.h
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <Core/RefCountedObject.h>
+
+namespace spades {
+	namespace gui {
+		class ConsoleCommand;
+
+		/** Responds to console commands for accessing config variables. */
+		class ConfigConsoleResponder {
+		public:
+			static bool ExecCommand(const Handle<ConsoleCommand> &);
+		};
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConfigConsoleResponder.h
+++ b/Sources/Gui/ConfigConsoleResponder.h
@@ -19,6 +19,9 @@
 #pragma once
 
 #include <Core/RefCountedObject.h>
+#include <string>
+
+#include "ConsoleCommandCandidate.h"
 
 namespace spades {
 	namespace gui {
@@ -28,6 +31,9 @@ namespace spades {
 		class ConfigConsoleResponder {
 		public:
 			static bool ExecCommand(const Handle<ConsoleCommand> &);
+
+			static Handle<ConsoleCommandCandidateIterator>
+			AutocompleteCommandName(const std::string &name);
 		};
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleCommand.cpp
+++ b/Sources/Gui/ConsoleCommand.cpp
@@ -1,0 +1,84 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <Core/Debug.h>
+#include <Core/Exception.h>
+#include <Core/Math.h>
+
+#include "ConsoleCommand.h"
+
+namespace spades {
+	namespace gui {
+		Handle<ConsoleCommand> ConsoleCommand::Parse(const std::string &textRaw) {
+			SPADES_MARK_FUNCTION();
+
+			Handle<ConsoleCommand> cmd{new ConsoleCommand(), false};
+
+			std::string const text = TrimSpaces(textRaw);
+			std::vector<std::string> parts;
+			std::size_t i = 0;
+			bool quoted = false;
+
+			parts.emplace_back();
+
+			while (i < text.size()) {
+				// Search for the next special characters. Whitespaces are
+				// treated as a parameter separator, except in a quotation.
+				std::size_t next = text.find_first_of(quoted ? "\"\\" : " \"\\", i);
+				if (next == std::string::npos) {
+					parts.back() += text.substr(i);
+					break;
+				}
+
+				parts.back() += text.substr(i, next - i);
+
+				switch (text[next]) {
+					case ' ':
+						parts.emplace_back();
+						i = next + 1;
+						break;
+					case '"':
+						quoted = !quoted;
+						i = next + 1;
+						break;
+					case '\\':
+						if (next + 1 >= text.size()) {
+							// No character to escape
+							SPRaise("Backslashes must be followed by an ASCII character.");
+						}
+						if (text[next + 1] < 0) {
+							// Non-ASCII UTF-8 character
+							SPRaise("Backslashes must be followed by an ASCII character.");
+						}
+						parts.back().push_back(text[next + 1]);
+						i = next + 2;
+						break;
+					default: SPUnreachable();
+				}
+			}
+
+			cmd->name = std::move(parts[0]);
+			parts.erase(parts.begin(), parts.begin() + 1);
+			cmd->args = std::move(parts);
+
+			return cmd;
+		}
+
+		ConsoleCommand::~ConsoleCommand() {}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleCommand.h
+++ b/Sources/Gui/ConsoleCommand.h
@@ -1,0 +1,65 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <string>
+#include <vector>
+
+#include <Core/RefCountedObject.h>
+
+namespace spades {
+	namespace gui {
+		/**
+		 * Represents a console command to be executed.
+		 */
+		class ConsoleCommand : public RefCountedObject {
+		public:
+			/**
+			 * Constructa a `ConsoleCommand` by parsing the given command
+			 * string.
+			 *
+			 * Throws an exception if parsing fails.
+			 *
+			 * @return A `ConsoleCommand` object representing the parsed command.
+			 */
+			static Handle<ConsoleCommand> Parse(const std::string &);
+
+			/**
+			 * Get the command name.
+			 */
+			const std::string &GetName() const { return name; }
+
+			/**
+			 * Get the number of arguments.
+			 */
+			std::size_t GetNumArguments() const { return args.size(); }
+
+			/**
+			 * Get the argument at the specified index `i`. `i` must be in
+			 * range `[0, GetNumArguments() - 1]`.
+			 */
+			const std::string &GetArgument(std::size_t i) const { return args.at(i); }
+
+		private:
+			ConsoleCommand() {}
+			~ConsoleCommand();
+
+			std::string name;
+			std::vector<std::string> args;
+		};
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleCommand.h
+++ b/Sources/Gui/ConsoleCommand.h
@@ -16,6 +16,8 @@
  You should have received a copy of the GNU General Public License
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
+
 #include <string>
 #include <vector>
 

--- a/Sources/Gui/ConsoleCommandCandidate.cpp
+++ b/Sources/Gui/ConsoleCommandCandidate.cpp
@@ -28,15 +28,20 @@ namespace spades {
 			class MergeConsoleCommandCandidates final : public ConsoleCommandCandidateIterator {
 				Handle<ConsoleCommandCandidateIterator> first;
 				Handle<ConsoleCommandCandidateIterator> second;
-				bool hasFirst : 1 = true;
-				bool hasSecond : 1 = true;
-				bool chooseSecond : 1 = false;
-				bool initial : 1 = false;
+				bool hasFirst : 1;
+				bool hasSecond : 1;
+				bool chooseSecond : 1;
+				bool initial : 1;
 
 			public:
 				MergeConsoleCommandCandidates(Handle<ConsoleCommandCandidateIterator> first,
 				                              Handle<ConsoleCommandCandidateIterator> second)
-				    : first{std::move(first)}, second{std::move(second)} {}
+				    : first{std::move(first)},
+				      second{std::move(second)},
+				      hasFirst{true},
+				      hasSecond{true},
+				      chooseSecond{false},
+				      initial{false} {}
 
 				const ConsoleCommandCandidate &GetCurrent() override {
 					SPADES_MARK_FUNCTION_DEBUG();

--- a/Sources/Gui/ConsoleCommandCandidate.cpp
+++ b/Sources/Gui/ConsoleCommandCandidate.cpp
@@ -41,7 +41,7 @@ namespace spades {
 				      hasFirst{true},
 				      hasSecond{true},
 				      chooseSecond{false},
-				      initial{false} {}
+				      initial{true} {}
 
 				const ConsoleCommandCandidate &GetCurrent() override {
 					SPADES_MARK_FUNCTION_DEBUG();

--- a/Sources/Gui/ConsoleCommandCandidate.cpp
+++ b/Sources/Gui/ConsoleCommandCandidate.cpp
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <utility>
+
+#include <Core/Debug.h>
+
+#include "ConsoleCommandCandidate.h"
+
+namespace spades {
+	namespace gui {
+		namespace {
+			class MergeConsoleCommandCandidates final : public ConsoleCommandCandidateIterator {
+				Handle<ConsoleCommandCandidateIterator> first;
+				Handle<ConsoleCommandCandidateIterator> second;
+				bool hasFirst : 1 = true;
+				bool hasSecond : 1 = true;
+				bool chooseSecond : 1 = false;
+				bool initial : 1 = false;
+
+			public:
+				MergeConsoleCommandCandidates(Handle<ConsoleCommandCandidateIterator> first,
+				                              Handle<ConsoleCommandCandidateIterator> second)
+				    : first{std::move(first)}, second{std::move(second)} {}
+
+				const ConsoleCommandCandidate &GetCurrent() override {
+					SPADES_MARK_FUNCTION_DEBUG();
+
+					return chooseSecond ? second->GetCurrent() : first->GetCurrent();
+				}
+
+				bool MoveNext() override {
+					SPADES_MARK_FUNCTION_DEBUG();
+
+					if (initial) {
+						hasFirst = first->MoveNext();
+						hasSecond = second->MoveNext();
+						initial = false;
+					} else {
+						if (chooseSecond) {
+							hasSecond = second->MoveNext();
+						} else {
+							hasFirst = first->MoveNext();
+						}
+					}
+
+					if (!hasSecond && !hasFirst) {
+						return false;
+					} else if (!hasFirst) {
+						chooseSecond = true;
+					} else if (!hasSecond) {
+						chooseSecond = false;
+					} else {
+						chooseSecond = second->GetCurrent().name < first->GetCurrent().name;
+					}
+
+					return true;
+				}
+			};
+		} // namespace
+
+		Handle<ConsoleCommandCandidateIterator>
+		MergeCandidates(Handle<ConsoleCommandCandidateIterator> first,
+		                Handle<ConsoleCommandCandidateIterator> second) {
+			SPADES_MARK_FUNCTION();
+
+			return {new MergeConsoleCommandCandidates{std::move(first), std::move(second)}, false};
+		}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleCommandCandidate.h
+++ b/Sources/Gui/ConsoleCommandCandidate.h
@@ -1,0 +1,51 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+#include <Core/Iterator.h>
+
+namespace spades {
+	namespace gui {
+		/**
+		 * Represents a candidate in console command name/value autocompletion.
+		 */
+		struct ConsoleCommandCandidate {
+			std::string name;
+			std::string description;
+		};
+
+		/**
+		 * A sequence of `ConsoleCommandCandidate`s. Must be sorted by
+		 * `ConsoleCommandCandidate::name`.
+		 */
+		using ConsoleCommandCandidateIterator = Iterator<const ConsoleCommandCandidate &>;
+
+		Handle<ConsoleCommandCandidateIterator>
+		MergeCandidates(Handle<ConsoleCommandCandidateIterator> first,
+		                Handle<ConsoleCommandCandidateIterator> second);
+
+		inline Handle<ConsoleCommandCandidateIterator>
+		operator+(Handle<ConsoleCommandCandidateIterator> first,
+		          Handle<ConsoleCommandCandidateIterator> second) {
+			return MergeCandidates(first, second);
+		}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleCommandCandidate.h
+++ b/Sources/Gui/ConsoleCommandCandidate.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <map>
 #include <string>
 
 #include <Core/Iterator.h>
@@ -37,6 +38,15 @@ namespace spades {
 		 * `ConsoleCommandCandidate::name`.
 		 */
 		using ConsoleCommandCandidateIterator = Iterator<const ConsoleCommandCandidate &>;
+
+		/**
+		 * Construct a `ConsoleCommandCandidateIterator` from the specified
+		 * `std::map`.
+		 *
+		 * The map should remain unmodified and outlive the returned iterator.
+		 */
+		Handle<ConsoleCommandCandidateIterator>
+		MakeCandidates(const std::map<std::string, std::string> &, const std::string &query);
 
 		Handle<ConsoleCommandCandidateIterator>
 		MergeCandidates(Handle<ConsoleCommandCandidateIterator> first,

--- a/Sources/Gui/ConsoleHelper.cpp
+++ b/Sources/Gui/ConsoleHelper.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2019 yvt
 
  This file is part of OpenSpades.
 
@@ -15,13 +15,17 @@
 
  You should have received a copy of the GNU General Public License
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
-
  */
+#include "ConsoleHelper.h"
 
-#include "UIFramework/UIFramework.as"
-#include "MessageBox.as"
-#include "MainScreen/MainScreenUI.as"
-#include "StartupScreen/StartupScreenUI.as"
-#include "Preferences.as"
-#include "Client/ClientUI.as"
-#include "Console/ConsoleUI.as"
+namespace spades {
+	namespace gui {
+		ConsoleHelper::ConsoleHelper(ConsoleScreen *scr) {
+			(void)scr;
+			// TODO
+		}
+		void ConsoleHelper::ConsoleScreenDestroyed() {
+			// TODO
+		}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleHelper.cpp
+++ b/Sources/Gui/ConsoleHelper.cpp
@@ -59,5 +59,17 @@ namespace spades {
 				SPLog("An exception was thrown while executing a console command: %s", e.what());
 			}
 		}
+
+		ConsoleCommandCandidateIterator *
+		ConsoleHelper::AutocompleteCommandName(const std::string &name) {
+			SPADES_MARK_FUNCTION();
+
+			auto parent = GetParent();
+			if (!parent) {
+				return new EmptyIterator<const ConsoleCommandCandidate &>();
+			}
+
+			return parent->AutocompleteCommandName(name).Unmanage();
+		}
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleHelper.cpp
+++ b/Sources/Gui/ConsoleHelper.cpp
@@ -21,10 +21,14 @@
 namespace spades {
 	namespace gui {
 		ConsoleHelper::ConsoleHelper(ConsoleScreen *scr) {
+			SPADES_MARK_FUNCTION();
+
 			(void)scr;
 			// TODO
 		}
 		void ConsoleHelper::ConsoleScreenDestroyed() {
+			SPADES_MARK_FUNCTION();
+
 			// TODO
 		}
 	} // namespace gui

--- a/Sources/Gui/ConsoleHelper.cpp
+++ b/Sources/Gui/ConsoleHelper.cpp
@@ -16,20 +16,48 @@
  You should have received a copy of the GNU General Public License
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <Core/Debug.h>
+
+#include "ConsoleCommand.h"
 #include "ConsoleHelper.h"
+#include "ConsoleScreen.h"
 
 namespace spades {
 	namespace gui {
 		ConsoleHelper::ConsoleHelper(ConsoleScreen *scr) {
 			SPADES_MARK_FUNCTION();
 
-			(void)scr;
-			// TODO
+			parentWeak = scr;
 		}
+
+		ConsoleHelper::~ConsoleHelper() {}
+
 		void ConsoleHelper::ConsoleScreenDestroyed() {
 			SPADES_MARK_FUNCTION();
 
-			// TODO
+			parentWeak = nullptr;
+		}
+
+		Handle<ConsoleScreen> ConsoleHelper::GetParent() { return {parentWeak, true}; }
+
+		void ConsoleHelper::ExecCommand(const std::string &text) {
+			SPADES_MARK_FUNCTION();
+
+			auto parent = GetParent();
+			if (!parent) {
+				return;
+			}
+
+			SPLog("Command: %s", text.c_str());
+			try {
+				auto const command = ConsoleCommand::Parse(text);
+
+				if (!parent->ExecCommand(command)) {
+					SPLog("Unknown command: '%s'", command->GetName().c_str());
+				}
+			} catch (const std::exception &e) {
+				SPLog("An exception was thrown while executing a console command: %s", e.what());
+			}
 		}
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleHelper.h
+++ b/Sources/Gui/ConsoleHelper.h
@@ -30,6 +30,16 @@ namespace spades {
 		public:
 			ConsoleHelper(ConsoleScreen *scr);
 			void ConsoleScreenDestroyed();
+
+			/** Execute a console command. */
+			void ExecCommand(const std::string &);
+
+		private:
+			~ConsoleHelper();
+			/** A weak reference to the owning `ConsoleScreen`. */
+			ConsoleScreen *parentWeak;
+			/** Get a strong reference to the owning `ConsoleScreen`. */
+			Handle<ConsoleScreen> GetParent();
 		};
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleHelper.h
+++ b/Sources/Gui/ConsoleHelper.h
@@ -16,6 +16,8 @@
  You should have received a copy of the GNU General Public License
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
+
 #include <Core/RefCountedObject.h>
 
 namespace spades {

--- a/Sources/Gui/ConsoleHelper.h
+++ b/Sources/Gui/ConsoleHelper.h
@@ -20,6 +20,8 @@
 
 #include <Core/RefCountedObject.h>
 
+#include "ConsoleCommandCandidate.h"
+
 namespace spades {
 	namespace gui {
 		class ConsoleScreen;
@@ -35,6 +37,9 @@ namespace spades {
 
 			/** Execute a console command. */
 			void ExecCommand(const std::string &);
+
+			/** Produce a sequence of candidates for command name autocompletion. */
+			ConsoleCommandCandidateIterator *AutocompleteCommandName(const std::string &name);
 
 		private:
 			~ConsoleHelper();

--- a/Sources/Gui/ConsoleHelper.h
+++ b/Sources/Gui/ConsoleHelper.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2019 yvt
 
  This file is part of OpenSpades.
 
@@ -15,13 +15,21 @@
 
  You should have received a copy of the GNU General Public License
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
-
  */
+#include <Core/RefCountedObject.h>
 
-#include "UIFramework/UIFramework.as"
-#include "MessageBox.as"
-#include "MainScreen/MainScreenUI.as"
-#include "StartupScreen/StartupScreenUI.as"
-#include "Preferences.as"
-#include "Client/ClientUI.as"
-#include "Console/ConsoleUI.as"
+namespace spades {
+	namespace gui {
+		class ConsoleScreen;
+
+		/**
+		 * Provides methods to be called by the AngelScript part of the system
+		 * console.
+		 */
+		class ConsoleHelper : public RefCountedObject {
+		public:
+			ConsoleHelper(ConsoleScreen *scr);
+			void ConsoleScreenDestroyed();
+		};
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -226,10 +226,12 @@ namespace spades {
 		namespace {
 			constexpr const char *CMD_HELP = "help";
 			constexpr const char *CMD_CLEARGFXCACHE = "cleargfxcache";
+			constexpr const char *CMD_CLEARSFXCACHE = "clearsfxcache";
 
 			std::map<std::string, std::string> const g_commands{
 			  {CMD_HELP, ": Display all available commands"},
 			  {CMD_CLEARGFXCACHE, ": Clear the GFX (models and images) cache, forcing reload"},
+			  {CMD_CLEARSFXCACHE, ": Clear the SFX cache, forcing reload"},
 			};
 		} // namespace
 
@@ -248,6 +250,13 @@ namespace spades {
 					return true;
 				}
 				renderer->ClearCache();
+				return true;
+			} else if (command->GetName() == CMD_CLEARSFXCACHE) {
+				if (command->GetNumArguments() != 0) {
+					SPLog("Usage: %s (no arguments)", CMD_CLEARSFXCACHE);
+					return true;
+				}
+				audioDevice->ClearCache();
 				return true;
 			}
 			return ConfigConsoleResponder::ExecCommand(command) || subview->ExecCommand(command);

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -29,6 +29,8 @@ namespace spades {
 		                             Handle<client::IAudioDevice> audioDevice,
 		                             Handle<client::FontManager> fontManager,
 		                             Handle<View> subview) {
+			SPADES_MARK_FUNCTION();
+
 			this->subview = subview;
 			renderer->Init();
 
@@ -49,9 +51,15 @@ namespace spades {
 			}
 		}
 
-		ConsoleScreen::~ConsoleScreen() { helper->ConsoleScreenDestroyed(); }
+		ConsoleScreen::~ConsoleScreen() {
+			SPADES_MARK_FUNCTION();
+
+			helper->ConsoleScreenDestroyed();
+		}
 
 		void ConsoleScreen::MouseEvent(float x, float y) {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "void MouseEvent(float, float)");
@@ -65,6 +73,8 @@ namespace spades {
 			}
 		}
 		void ConsoleScreen::KeyEvent(const std::string &key, bool down) {
+			SPADES_MARK_FUNCTION();
+
 			// TODO: Check if "`" is correct
 			if (key == "`" || key == "F1") {
 				if (down) {
@@ -87,6 +97,8 @@ namespace spades {
 			}
 		}
 		void ConsoleScreen::TextInputEvent(const std::string &ch) {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "void TextInputEvent(string)");
@@ -100,6 +112,8 @@ namespace spades {
 			}
 		}
 		void ConsoleScreen::TextEditingEvent(const std::string &ch, int start, int len) {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "void TextEditingEvent(string, int, int)");
@@ -115,6 +129,8 @@ namespace spades {
 			}
 		}
 		bool ConsoleScreen::AcceptsTextInput() {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "bool AcceptsTextInput()");
@@ -127,6 +143,8 @@ namespace spades {
 			}
 		}
 		AABB2 ConsoleScreen::GetTextInputRect() {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "AABB2 GetTextInputRect()");
@@ -139,6 +157,8 @@ namespace spades {
 			}
 		}
 		void ConsoleScreen::WheelEvent(float x, float y) {
+			SPADES_MARK_FUNCTION();
+
 			if (ShouldInterceptInput()) {
 				ScopedPrivilegeEscalation privilege;
 				static ScriptFunction func("ConsoleUI", "void WheelEvent(float, float)");
@@ -152,10 +172,14 @@ namespace spades {
 			}
 		}
 		bool ConsoleScreen::NeedsAbsoluteMouseCoordinate() {
+			SPADES_MARK_FUNCTION();
+
 			return ShouldInterceptInput() ? true : subview->NeedsAbsoluteMouseCoordinate();
 		}
 
 		void ConsoleScreen::RunFrame(float dt) {
+			SPADES_MARK_FUNCTION();
+
 			subview->RunFrame(dt);
 
 			ScopedPrivilegeEscalation privilege;
@@ -166,13 +190,24 @@ namespace spades {
 			c.ExecuteChecked();
 		}
 
-		void ConsoleScreen::RunFrameLate(float dt) { subview->RunFrameLate(dt); }
+		void ConsoleScreen::RunFrameLate(float dt) {
+			SPADES_MARK_FUNCTION();
+			subview->RunFrameLate(dt);
+		}
 
-		void ConsoleScreen::Closing() { subview->Closing(); }
+		void ConsoleScreen::Closing() {
+			SPADES_MARK_FUNCTION();
+			subview->Closing();
+		}
 
-		bool ConsoleScreen::WantsToBeClosed() { return subview->WantsToBeClosed(); }
+		bool ConsoleScreen::WantsToBeClosed() {
+			SPADES_MARK_FUNCTION();
+			return subview->WantsToBeClosed();
+		}
 
 		bool ConsoleScreen::ShouldInterceptInput() {
+			SPADES_MARK_FUNCTION();
+
 			ScopedPrivilegeEscalation privilege;
 			static ScriptFunction func("ConsoleUI", "bool ShouldInterceptInput()");
 			ScriptContextHandle c = func.Prepare();
@@ -182,6 +217,8 @@ namespace spades {
 		}
 
 		void ConsoleScreen::ToggleConsole() {
+			SPADES_MARK_FUNCTION();
+
 			ScopedPrivilegeEscalation privilege;
 			static ScriptFunction func("ConsoleUI", "void ToggleConsole()");
 			ScriptContextHandle c = func.Prepare();
@@ -190,6 +227,8 @@ namespace spades {
 		}
 
 		void ConsoleScreen::AddLine(const std::string &line) {
+			SPADES_MARK_FUNCTION();
+
 			ScopedPrivilegeEscalation privilege;
 			static ScriptFunction func("ConsoleUI", "void AddLine(string)");
 			ScriptContextHandle c = func.Prepare();

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -29,11 +29,10 @@ namespace spades {
 	namespace gui {
 		ConsoleScreen::ConsoleScreen(Handle<client::IRenderer> renderer,
 		                             Handle<client::IAudioDevice> audioDevice,
-		                             Handle<client::FontManager> fontManager,
-		                             Handle<View> subview) {
+		                             Handle<client::FontManager> fontManager, Handle<View> subview)
+		    : renderer{renderer}, audioDevice{audioDevice}, subview{subview} {
 			SPADES_MARK_FUNCTION();
 
-			this->subview = subview;
 			renderer->Init();
 
 			helper.Set(new ConsoleHelper(this), true);
@@ -226,9 +225,11 @@ namespace spades {
 
 		namespace {
 			constexpr const char *CMD_HELP = "help";
+			constexpr const char *CMD_CLEARGFXCACHE = "cleargfxcache";
 
 			std::map<std::string, std::string> const g_commands{
 			  {CMD_HELP, ": Display all available commands"},
+			  {CMD_CLEARGFXCACHE, ": Clear the GFX (models and images) cache, forcing reload"},
 			};
 		} // namespace
 
@@ -236,10 +237,17 @@ namespace spades {
 			SPADES_MARK_FUNCTION();
 			if (command->GetName() == CMD_HELP) {
 				if (command->GetNumArguments() != 0) {
-					SPLog("Usage: help (no arguments)");
+					SPLog("Usage: %s (no arguments)", CMD_HELP);
 					return true;
 				}
 				DumpAllCommands();
+				return true;
+			} else if (command->GetName() == CMD_CLEARGFXCACHE) {
+				if (command->GetNumArguments() != 0) {
+					SPLog("Usage: %s (no arguments)", CMD_CLEARGFXCACHE);
+					return true;
+				}
+				renderer->ClearCache();
 				return true;
 			}
 			return ConfigConsoleResponder::ExecCommand(command) || subview->ExecCommand(command);

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -219,6 +219,12 @@ namespace spades {
 			return ConfigConsoleResponder::ExecCommand(command) || subview->ExecCommand(command);
 		}
 
+		Handle<ConsoleCommandCandidateIterator>
+		ConsoleScreen::AutocompleteCommandName(const std::string &name) {
+			SPADES_MARK_FUNCTION();
+			return subview->AutocompleteCommandName(name);
+		}
+
 		bool ConsoleScreen::ShouldInterceptInput() {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -33,8 +33,6 @@ namespace spades {
 		    : renderer{renderer}, audioDevice{audioDevice}, subview{subview} {
 			SPADES_MARK_FUNCTION();
 
-			renderer->Init();
-
 			helper.Set(new ConsoleHelper(this), true);
 
 			ScopedPrivilegeEscalation privilege;

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -188,5 +188,15 @@ namespace spades {
 			c->SetObject(&*ui);
 			c.ExecuteChecked();
 		}
+
+		void ConsoleScreen::AddLine(const std::string &line) {
+			ScopedPrivilegeEscalation privilege;
+			static ScriptFunction func("ConsoleUI", "void AddLine(string)");
+			ScriptContextHandle c = func.Prepare();
+			std::string k = line;
+			c->SetObject(&*ui);
+			c->SetArgObject(0, reinterpret_cast<void *>(&k));
+			c.ExecuteChecked();
+		}
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -180,6 +180,14 @@ namespace spades {
 		void ConsoleScreen::RunFrame(float dt) {
 			SPADES_MARK_FUNCTION();
 
+			// Read the global log buffer dedicated to `ConsoleScreen`
+			GetBufferedLogLines(stmp::make_fn<void(std::string)>([this](std::string entry) {
+				auto lines = SplitIntoLines(entry);
+				for (const auto &line : lines) {
+					AddLine(line);
+				}
+			}));
+
 			subview->RunFrame(dt);
 
 			ScopedPrivilegeEscalation privilege;

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -205,6 +205,11 @@ namespace spades {
 			return subview->WantsToBeClosed();
 		}
 
+		bool ConsoleScreen::ExecCommand(const Handle<ConsoleCommand> &command) {
+			SPADES_MARK_FUNCTION();
+			return subview->ExecCommand(command);
+		}
+
 		bool ConsoleScreen::ShouldInterceptInput() {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -222,7 +222,8 @@ namespace spades {
 		Handle<ConsoleCommandCandidateIterator>
 		ConsoleScreen::AutocompleteCommandName(const std::string &name) {
 			SPADES_MARK_FUNCTION();
-			return subview->AutocompleteCommandName(name);
+			return ConfigConsoleResponder::AutocompleteCommandName(name) +
+			       subview->AutocompleteCommandName(name);
 		}
 
 		bool ConsoleScreen::ShouldInterceptInput() {

--- a/Sources/Gui/ConsoleScreen.cpp
+++ b/Sources/Gui/ConsoleScreen.cpp
@@ -20,6 +20,7 @@
 #include <ScriptBindings/Config.h>
 #include <ScriptBindings/ScriptFunction.h>
 
+#include "ConfigConsoleResponder.h"
 #include "ConsoleHelper.h"
 #include "ConsoleScreen.h"
 
@@ -215,7 +216,7 @@ namespace spades {
 
 		bool ConsoleScreen::ExecCommand(const Handle<ConsoleCommand> &command) {
 			SPADES_MARK_FUNCTION();
-			return subview->ExecCommand(command);
+			return ConfigConsoleResponder::ExecCommand(command) || subview->ExecCommand(command);
 		}
 
 		bool ConsoleScreen::ShouldInterceptInput() {

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -63,6 +63,7 @@ namespace spades {
 			Handle<asIScriptObject> ui;
 			bool ShouldInterceptInput();
 			void ToggleConsole();
+			void AddLine(const std::string &);
 		};
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -1,0 +1,68 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "View.h"
+#include <Client/IAudioDevice.h>
+#include <Client/IRenderer.h>
+#include <ScriptBindings/ScriptManager.h>
+
+namespace spades {
+	namespace client {
+		class FontManager;
+	}
+	namespace gui {
+		class ConsoleHelper;
+
+		/**
+		 * This `View` wraps another `View` to provide the system console
+		 * functionality which can be invoked anytime by using a hotkey.
+		 */
+		class ConsoleScreen : public View {
+		public:
+			ConsoleScreen(Handle<client::IRenderer>, Handle<client::IAudioDevice>,
+			              Handle<client::FontManager>, Handle<View>);
+
+			// Implements `View`
+			void MouseEvent(float x, float y) override;
+			void KeyEvent(const std::string &, bool down) override;
+			void TextInputEvent(const std::string &) override;
+			void TextEditingEvent(const std::string &, int start, int len) override;
+			bool AcceptsTextInput() override;
+			AABB2 GetTextInputRect() override;
+			void WheelEvent(float x, float y) override;
+			bool NeedsAbsoluteMouseCoordinate() override;
+			void RunFrame(float dt) override;
+			void RunFrameLate(float dt) override;
+			void Closing() override;
+			bool WantsToBeClosed() override;
+
+		private:
+			~ConsoleScreen();
+
+			Handle<View> subview;
+
+			// Scripting
+			Handle<ConsoleHelper> helper;
+			Handle<asIScriptObject> ui;
+			bool ShouldInterceptInput();
+			void ToggleConsole();
+		};
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -54,6 +54,8 @@ namespace spades {
 			void Closing() override;
 			bool WantsToBeClosed() override;
 			bool ExecCommand(const Handle<ConsoleCommand> &) override;
+			Handle<ConsoleCommandCandidateIterator>
+			AutocompleteCommandName(const std::string &name) override;
 
 		private:
 			~ConsoleScreen();

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -60,6 +60,8 @@ namespace spades {
 		private:
 			~ConsoleScreen();
 
+			Handle<client::IRenderer> renderer;
+			Handle<client::IAudioDevice> audioDevice;
 			Handle<View> subview;
 
 			// Scripting

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -68,6 +68,9 @@ namespace spades {
 			bool ShouldInterceptInput();
 			void ToggleConsole();
 			void AddLine(const std::string &);
+
+			/** Dump all available commands to `SPLog`. */
+			void DumpAllCommands();
 		};
 	} // namespace gui
 } // namespace spades

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -52,6 +52,7 @@ namespace spades {
 			void RunFrameLate(float dt) override;
 			void Closing() override;
 			bool WantsToBeClosed() override;
+			bool ExecCommand(const Handle<ConsoleCommand> &) override;
 
 		private:
 			~ConsoleScreen();

--- a/Sources/Gui/ConsoleScreen.h
+++ b/Sources/Gui/ConsoleScreen.h
@@ -35,6 +35,7 @@ namespace spades {
 		 * functionality which can be invoked anytime by using a hotkey.
 		 */
 		class ConsoleScreen : public View {
+			friend class ConsoleHelper;
 		public:
 			ConsoleScreen(Handle<client::IRenderer>, Handle<client::IAudioDevice>,
 			              Handle<client::FontManager>, Handle<View>);

--- a/Sources/Gui/MainScreen.cpp
+++ b/Sources/Gui/MainScreen.cpp
@@ -233,13 +233,7 @@ namespace spades {
 			if (subview) {
 				try {
 					subview->RunFrame(dt);
-					if (subview->WantsToBeClosed()) {
-						subview->Closing();
-						subview = NULL;
-						RestoreRenderer();
-					} else {
-						return;
-					}
+					return;
 				} catch (const std::exception &ex) {
 					SPLog("[!] Error while running a game client: %s", ex.what());
 					subview->Closing();
@@ -263,6 +257,38 @@ namespace spades {
 
 			ScopedPrivilegeEscalation privilege;
 			static ScriptFunction func("MainScreenUI", "void RunFrame(float)");
+			ScriptContextHandle c = func.Prepare();
+			c->SetObject(&*ui);
+			c->SetArgFloat(0, dt);
+			c.ExecuteChecked();
+		}
+
+		void MainScreen::RunFrameLate(float dt) {
+			SPADES_MARK_FUNCTION();
+			if (subview) {
+				try {
+					subview->RunFrameLate(dt);
+					if (subview->WantsToBeClosed()) {
+						subview->Closing();
+						subview = NULL;
+						RestoreRenderer();
+					} else {
+						return;
+					}
+				} catch (const std::exception &ex) {
+					SPLog("[!] Error while running a game client: %s", ex.what());
+					subview->Closing();
+					subview = NULL;
+					RestoreRenderer();
+					helper->errorMessage = ex.what();
+				}
+			}
+
+            if (!ui) {
+            	return;
+            }
+			ScopedPrivilegeEscalation privilege;
+			static ScriptFunction func("MainScreenUI", "void RunFrameLate(float)");
 			ScriptContextHandle c = func.Prepare();
 			c->SetObject(&*ui);
 			c->SetArgFloat(0, dt);

--- a/Sources/Gui/MainScreen.cpp
+++ b/Sources/Gui/MainScreen.cpp
@@ -284,9 +284,9 @@ namespace spades {
 				}
 			}
 
-            if (!ui) {
-            	return;
-            }
+			if (!ui) {
+				return;
+			}
 			ScopedPrivilegeEscalation privilege;
 			static ScriptFunction func("MainScreenUI", "void RunFrameLate(float)");
 			ScriptContextHandle c = func.Prepare();
@@ -331,10 +331,26 @@ namespace spades {
 			c.ExecuteChecked();
 		}
 
+		bool MainScreen::ExecCommand(const Handle<ConsoleCommand> &cmd) {
+			SPADES_MARK_FUNCTION();
+			if (subview) {
+				return subview->ExecCommand(cmd);
+			}
+			return View::ExecCommand(cmd);
+		}
+
+		Handle<ConsoleCommandCandidateIterator>
+		MainScreen::AutocompleteCommandName(const std::string &name) {
+			SPADES_MARK_FUNCTION();
+			if (subview) {
+				return subview->AutocompleteCommandName(name);
+			}
+			return View::AutocompleteCommandName(name);
+		}
+
 		std::string MainScreen::Connect(const ServerAddress &host) {
 			try {
-				subview.Set(new client::Client(&*renderer, &*audioDevice, host,
-				                               fontManager),
+				subview.Set(new client::Client(&*renderer, &*audioDevice, host, fontManager),
 				            false);
 			} catch (const std::exception &ex) {
 				SPLog("[!] Error while initializing a game client: %s", ex.what());
@@ -342,5 +358,5 @@ namespace spades {
 			}
 			return "";
 		}
-	}
-}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/MainScreen.h
+++ b/Sources/Gui/MainScreen.h
@@ -73,9 +73,11 @@ namespace spades {
 			void RunFrameLate(float dt) override;
 
 			void Closing() override;
-
 			bool WantsToBeClosed() override;
+
+			bool ExecCommand(const Handle<ConsoleCommand> &) override;
+			Handle<ConsoleCommandCandidateIterator>
+			AutocompleteCommandName(const std::string &name) override;
 		};
-		;
-	}
-}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/MainScreen.h
+++ b/Sources/Gui/MainScreen.h
@@ -70,6 +70,7 @@ namespace spades {
 			bool NeedsAbsoluteMouseCoordinate() override;
 
 			void RunFrame(float dt) override;
+			void RunFrameLate(float dt) override;
 
 			void Closing() override;
 

--- a/Sources/Gui/SDLRunner.cpp
+++ b/Sources/Gui/SDLRunner.cpp
@@ -212,8 +212,10 @@ namespace spades {
 					}
 
 					ot += dt;
-					if ((int32_t)dt > 0)
+					if ((int32_t)dt > 0) {
 						view->RunFrame((float)dt / 1000.f);
+						view->RunFrameLate((float)dt / 1000.f);
+					}
 
 					if (view->WantsToBeClosed()) {
 						view->Closing();

--- a/Sources/Gui/StartupScreen.cpp
+++ b/Sources/Gui/StartupScreen.cpp
@@ -220,6 +220,17 @@ namespace spades {
 			c.ExecuteChecked();
 		}
 
+		void StartupScreen::RunFrameLate(float dt) {
+			SPADES_MARK_FUNCTION();
+
+			ScopedPrivilegeEscalation privilege;
+			static ScriptFunction func("StartupScreenUI", "void RunFrameLate(float)");
+			ScriptContextHandle c = func.Prepare();
+			c->SetObject(&*ui);
+			c->SetArgFloat(0, dt);
+			c.ExecuteChecked();
+		}
+
 		void StartupScreen::DoInit() {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Gui/StartupScreen.h
+++ b/Sources/Gui/StartupScreen.h
@@ -71,6 +71,7 @@ namespace spades {
 			bool NeedsAbsoluteMouseCoordinate() override;
 
 			void RunFrame(float dt) override;
+			void RunFrameLate(float dt) override;
 
 			void Closing() override;
 

--- a/Sources/Gui/View.cpp
+++ b/Sources/Gui/View.cpp
@@ -17,9 +17,13 @@
  along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
 
  */
-
 #include "View.h"
 
 namespace spades {
-	namespace gui {}
-}
+	namespace gui {
+		Handle<ConsoleCommandCandidateIterator>
+		View::AutocompleteCommandName(const std::string &name) {
+			return {new EmptyIterator<const ConsoleCommandCandidate &>(), false};
+		}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/View.h
+++ b/Sources/Gui/View.h
@@ -25,6 +25,8 @@
 
 namespace spades {
 	namespace gui {
+		class ConsoleCommand;
+
 		class View : public RefCountedObject {
 		protected:
 			virtual ~View() {}
@@ -49,6 +51,13 @@ namespace spades {
 			virtual void Closing() {}
 
 			virtual bool WantsToBeClosed() { return false; }
+
+			/**
+			 * Execute a console command.
+			 *
+			 * @return `true` if the command was handled.
+			 */
+			virtual bool ExecCommand(const Handle<ConsoleCommand> &) { return false; }
 		};
-	}
-}
+	} // namespace gui
+} // namespace spades

--- a/Sources/Gui/View.h
+++ b/Sources/Gui/View.h
@@ -41,7 +41,10 @@ namespace spades {
 			virtual bool NeedsAbsoluteMouseCoordinate() { return false; }
 			virtual void WheelEvent(float x, float y) {}
 
+			/** Called for every frame. */
 			virtual void RunFrame(float dt) {}
+			/** Called for every frame after `RunFrame`. */
+			virtual void RunFrameLate(float dt) {}
 
 			virtual void Closing() {}
 

--- a/Sources/Gui/View.h
+++ b/Sources/Gui/View.h
@@ -62,7 +62,7 @@ namespace spades {
 			virtual bool ExecCommand(const Handle<ConsoleCommand> &) { return false; }
 
 			/**
-			 * Produce a sequence of candidates of command name autocompletion.
+			 * Produce a sequence of candidates for command name autocompletion.
 			 *
 			 * `name` is an incomplete command name. This method produces
 			 * a sequence of candidates starting with `name`.

--- a/Sources/Gui/View.h
+++ b/Sources/Gui/View.h
@@ -23,6 +23,8 @@
 #include <Core/Math.h>
 #include <Core/RefCountedObject.h>
 
+#include "ConsoleCommandCandidate.h"
+
 namespace spades {
 	namespace gui {
 		class ConsoleCommand;
@@ -58,6 +60,15 @@ namespace spades {
 			 * @return `true` if the command was handled.
 			 */
 			virtual bool ExecCommand(const Handle<ConsoleCommand> &) { return false; }
+
+			/**
+			 * Produce a sequence of candidates of command name autocompletion.
+			 *
+			 * `name` is an incomplete command name. This method produces
+			 * a sequence of candidates starting with `name`.
+			 */
+			virtual Handle<ConsoleCommandCandidateIterator>
+			AutocompleteCommandName(const std::string &name);
 		};
 	} // namespace gui
 } // namespace spades

--- a/Sources/ScriptBindings/ConsoleCommandCandidate.cpp
+++ b/Sources/ScriptBindings/ConsoleCommandCandidate.cpp
@@ -30,6 +30,10 @@ namespace spades {
 		                                            gui::ConsoleCommandCandidate *p) {
 			new (p) gui::ConsoleCommandCandidate(other);
 		}
+		static void ConsoleCommandCandidateAssign(const gui::ConsoleCommandCandidate &other,
+		                                          gui::ConsoleCommandCandidate *p) {
+			*p = other;
+		}
 		static void ConsoleCommandCandidateDestructor(gui::ConsoleCommandCandidate *p) {
 			p->~ConsoleCommandCandidate();
 		}
@@ -64,6 +68,10 @@ namespace spades {
 					r = eng->RegisterObjectBehaviour(
 					  "ConsoleCommandCandidate", asBEHAVE_DESTRUCT, "void f()",
 					  asFUNCTION(ConsoleCommandCandidateDestructor), asCALL_CDECL_OBJLAST);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ConsoleCommandCandidate", "void opAssign(const ConsoleCommandCandidate& in)",
+					  asFUNCTION(ConsoleCommandCandidateAssign), asCALL_CDECL_OBJLAST);
 					manager->CheckError(r);
 					r = eng->RegisterObjectProperty("ConsoleCommandCandidate", "string Name",
 					                                asOFFSET(gui::ConsoleCommandCandidate, name));

--- a/Sources/ScriptBindings/ConsoleCommandCandidate.cpp
+++ b/Sources/ScriptBindings/ConsoleCommandCandidate.cpp
@@ -1,0 +1,101 @@
+/*
+ Copyright (c) 2019 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include "ScriptManager.h"
+#include <Gui/ConsoleCommandCandidate.h>
+
+namespace spades {
+	class ConsoleCommandCandidateRegistrar : public ScriptObjectRegistrar {
+		static void ConsoleCommandCandidateFactory1(gui::ConsoleCommandCandidate *p) {
+			new (p) gui::ConsoleCommandCandidate();
+		}
+		static void ConsoleCommandCandidateFactory2(const gui::ConsoleCommandCandidate &other,
+		                                            gui::ConsoleCommandCandidate *p) {
+			new (p) gui::ConsoleCommandCandidate(other);
+		}
+		static void ConsoleCommandCandidateDestructor(gui::ConsoleCommandCandidate *p) {
+			p->~ConsoleCommandCandidate();
+		}
+
+	public:
+		ConsoleCommandCandidateRegistrar() : ScriptObjectRegistrar("ConsoleCommandCandidate") {}
+
+		virtual void Register(ScriptManager *manager, Phase phase) {
+			asIScriptEngine *eng = manager->GetEngine();
+			int r;
+			eng->SetDefaultNamespace("spades");
+			switch (phase) {
+				case PhaseObjectType:
+					r = eng->RegisterObjectType("ConsoleCommandCandidate",
+					                            sizeof(gui::ConsoleCommandCandidate),
+					                            asOBJ_VALUE | asOBJ_APP_CLASS_CDAK);
+					manager->CheckError(r);
+
+					r = eng->RegisterObjectType("ConsoleCommandCandidateIterator", 0, asOBJ_REF);
+					manager->CheckError(r);
+					break;
+				case PhaseObjectMember:
+					r = eng->RegisterObjectBehaviour(
+					  "ConsoleCommandCandidate", asBEHAVE_CONSTRUCT, "void f()",
+					  asFUNCTION(ConsoleCommandCandidateFactory1), asCALL_CDECL_OBJLAST);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour("ConsoleCommandCandidate", asBEHAVE_CONSTRUCT,
+					                                 "void f(const ConsoleCommandCandidate& in)",
+					                                 asFUNCTION(ConsoleCommandCandidateFactory2),
+					                                 asCALL_CDECL_OBJLAST);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour(
+					  "ConsoleCommandCandidate", asBEHAVE_DESTRUCT, "void f()",
+					  asFUNCTION(ConsoleCommandCandidateDestructor), asCALL_CDECL_OBJLAST);
+					manager->CheckError(r);
+					r = eng->RegisterObjectProperty("ConsoleCommandCandidate", "string Name",
+					                                asOFFSET(gui::ConsoleCommandCandidate, name));
+					manager->CheckError(r);
+					r = eng->RegisterObjectProperty(
+					  "ConsoleCommandCandidate", "string Description",
+					  asOFFSET(gui::ConsoleCommandCandidate, description));
+					manager->CheckError(r);
+
+					r = eng->RegisterObjectBehaviour(
+					  "ConsoleCommandCandidateIterator", asBEHAVE_ADDREF, "void f()",
+					  asMETHOD(gui::ConsoleCommandCandidateIterator, AddRef), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour(
+					  "ConsoleCommandCandidateIterator", asBEHAVE_RELEASE, "void f()",
+					  asMETHOD(gui::ConsoleCommandCandidateIterator, Release), asCALL_THISCALL);
+					manager->CheckError(r);
+
+					r = eng->RegisterObjectMethod(
+					  "ConsoleCommandCandidateIterator", "bool MoveNext()",
+					  asMETHOD(gui::ConsoleCommandCandidateIterator, MoveNext), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ConsoleCommandCandidateIterator",
+					  "const ConsoleCommandCandidate &get_Current()",
+					  asMETHOD(gui::ConsoleCommandCandidateIterator, GetCurrent), asCALL_THISCALL);
+					manager->CheckError(r);
+					break;
+				default: break;
+			}
+		}
+	};
+
+	static ConsoleCommandCandidateRegistrar registrar;
+} // namespace spades

--- a/Sources/ScriptBindings/ConsoleHelper.cpp
+++ b/Sources/ScriptBindings/ConsoleHelper.cpp
@@ -45,6 +45,11 @@ namespace spades {
 					                                 asMETHOD(gui::ConsoleHelper, Release),
 					                                 asCALL_THISCALL);
 					manager->CheckError(r);
+
+					r = eng->RegisterObjectMethod(
+					  "ConsoleHelper", "void ExecCommand(const string& in)",
+					  asMETHOD(gui::ConsoleHelper, ExecCommand), asCALL_THISCALL);
+					manager->CheckError(r);
 					break;
 				default: break;
 			}

--- a/Sources/ScriptBindings/ConsoleHelper.cpp
+++ b/Sources/ScriptBindings/ConsoleHelper.cpp
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) 2013 yvt
+
+ This file is part of OpenSpades.
+
+ OpenSpades is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OpenSpades is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OpenSpades.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+#include "ScriptManager.h"
+#include <Gui/ConsoleHelper.h>
+
+namespace spades {
+	class ConsoleHelperRegistrar : public ScriptObjectRegistrar {
+
+	public:
+		ConsoleHelperRegistrar() : ScriptObjectRegistrar("ConsoleHelper") {}
+
+		virtual void Register(ScriptManager *manager, Phase phase) {
+			asIScriptEngine *eng = manager->GetEngine();
+			int r;
+			eng->SetDefaultNamespace("spades");
+			switch (phase) {
+				case PhaseObjectType:
+					r = eng->RegisterObjectType("ConsoleHelper", 0, asOBJ_REF);
+					manager->CheckError(r);
+					break;
+				case PhaseObjectMember:
+					r = eng->RegisterObjectBehaviour("ConsoleHelper", asBEHAVE_ADDREF, "void f()",
+					                                 asMETHOD(gui::ConsoleHelper, AddRef),
+					                                 asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectBehaviour("ConsoleHelper", asBEHAVE_RELEASE, "void f()",
+					                                 asMETHOD(gui::ConsoleHelper, Release),
+					                                 asCALL_THISCALL);
+					manager->CheckError(r);
+					break;
+				default: break;
+			}
+		}
+	};
+
+	static ConsoleHelperRegistrar registrar;
+} // namespace spades

--- a/Sources/ScriptBindings/ConsoleHelper.cpp
+++ b/Sources/ScriptBindings/ConsoleHelper.cpp
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2013 yvt
+ Copyright (c) 2019 yvt
 
  This file is part of OpenSpades.
 
@@ -49,6 +49,11 @@ namespace spades {
 					r = eng->RegisterObjectMethod(
 					  "ConsoleHelper", "void ExecCommand(const string& in)",
 					  asMETHOD(gui::ConsoleHelper, ExecCommand), asCALL_THISCALL);
+					manager->CheckError(r);
+					r = eng->RegisterObjectMethod(
+					  "ConsoleHelper",
+					  "ConsoleCommandCandidateIterator@ AutocompleteCommandName(const string& in)",
+					  asMETHOD(gui::ConsoleHelper, AutocompleteCommandName), asCALL_THISCALL);
 					manager->CheckError(r);
 					break;
 				default: break;

--- a/Sources/ScriptBindings/IRenderer.cpp
+++ b/Sources/ScriptBindings/IRenderer.cpp
@@ -394,6 +394,11 @@ namespace spades {
 													  asFUNCTION(RegisterModel),
 													  asCALL_CDECL_OBJLAST);
 						manager->CheckError(r);
+						r = eng->RegisterObjectMethod("Renderer",
+													  "void ClearCache()",
+													  asMETHOD(IRenderer, ClearCache),
+													  asCALL_THISCALL);
+						manager->CheckError(r);
 						// OpenSpades' C++ functions increase the reference count of a passed object
 						// when storing it (just like the convention of Objective C), so we must
 						// use "auto handles" (`@+`).  Otherwise, a memory leak would occur


### PR DESCRIPTION
This PR adds an internal console window similar to the one seen in certain old-school PC games.

![Screen Shot 2019-07-14 at 20 42 10 copy](https://user-images.githubusercontent.com/5253988/61183125-0d3e8c00-a678-11e9-88e2-88c263566554.jpg)

![Screen Shot 2019-07-15 at 0 24 51 copy](https://user-images.githubusercontent.com/5253988/61185687-19861180-a697-11e9-8f11-ae5ef3a09656.jpg)

- The console window serves as an interface to hidden functionalities such as hot skin reloading (#841), [in-game config variable modification](https://github.com/yvt/openspades/wiki/Config-Variables), and demo recording (#57).
- It can be accessed anywhere in the game including `MainScreen`, since it's implemented in a lower level (think of Windows NT's <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Delete</kbd>).
    - Technically, it can be made invokable even from `StartupScreen`, but I decided not to do so.
- In addition to the existing destinations, `SPLog` is also redirected to this new console window. The history size is limited and old entries are removed from memory as new one arrives (this is mandatory because the amount of log produced by `SPLog` is large).
- It's toggled by <kbd>\`</kbd>. <kbd>F1</kbd> is also accepted because some keyboard layouts don't have <kbd>\`</kbd>.
- It's modal; it intercepts all inputs when active.
- Unlike some implementations, it is **not** dual-purposed as a chat window.

## Task List

- [x] Add `View::RunFrameLate`
- [x] Add `ConsoleScreen` (a `View` that wraps another `View` to insert the console window 2D layer and intercept the input)
- [x] Implement the user interface (`ConsoleWindow`)
- [x] Deprecate the old in-game config variable modification functionality that uses the chat window. Show an alert whenever this feature is used to encourage the transition.
- [x] Add something like `View::RunCommand`
- [x] "Launch title"
    - [x] `varname value` — In-game config variable modification
    - [x] `savemap`
    - [x] (Maybe?) `cleargfxcache` — Unloads voxel models, forcing reload
    - [x] (Maybe?) `clearsfxcache` — Unloads audio chunks, forcing reload
    - [x] `help`
- [x] Autocompletion
- [x] Redirect `SPLog`
