### PR TITLE
Fixed map loading with protocol 0.76.

### DIFF
--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -88,6 +88,7 @@ namespace spades {
 				PacketTypeWeaponReload = 28,    // C2S2P
 				PacketTypeChangeTeam = 29,      // C2S2P
 				PacketTypeChangeWeapon = 30,    // C2S2P
+				PacketTypeMapCached = 31,       // S2C
 				PacketTypeHandShakeInit = 31,   // S2C
 				PacketTypeHandShakeReturn = 32, // C2S
 				PacketTypeVersionGet = 33,      // S2C
@@ -1299,6 +1300,11 @@ namespace spades {
 				} break;
 				case PacketTypeMapStart: {
 					// next map!
+					if (protocolVersion == 4) {
+						NetPacketWriter wri(PacketTypeMapCached);
+						wri.Write((uint8_t)0);
+						enet_peer_send(peer, 0, wri.CreatePacket());
+					}
 					client->SetWorld(NULL);
 
 					auto mapSize = reader.ReadInt();

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -1301,6 +1301,11 @@ namespace spades {
 				case PacketTypeMapStart: {
 					// next map!
 					if (protocolVersion == 4) {
+						// The AoS 0.76 protocol allows the client to load a map from a local cache
+						// if possible. After receiving MapStart, the client should respond with
+						// MapCached to indicate whether the map with a given checksum exists in the
+						// cache or not. We don't implement a local cache, so we always ask the
+						// server to send fresh map data.
 						NetPacketWriter wri(PacketTypeMapCached);
 						wri.Write((uint8_t)0);
 						enet_peer_send(peer, 0, wri.CreatePacket());


### PR DESCRIPTION
This solution is copied from a commit in another fork:
https://github.com/BR-/openspades/commit/d4a7934291373c97bfbc6774729a96b14edf343e

I don't really understand what the commit does, but it fixes the issue with map loading on 0.76 servers (#847).