### PR TITLE
Fix aim-down-sight sound when ammo count is zero

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.errorSquiggles": "Disabled"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.errorSquiggles": "Disabled"
+}

--- a/Sources/Client/Client_Input.cpp
+++ b/Sources/Client/Client_Input.cpp
@@ -440,7 +440,7 @@ namespace spades {
 							weapInput.secondary = down;
 						}
 						if (world->GetLocalPlayer()->IsToolWeapon() && weapInput.secondary &&
-						    !lastVal && world->GetLocalPlayer()->IsReadyToUseTool() &&
+						    !lastVal && world->GetLocalPlayer()->GetWeapon()->TimeToNextFire() <= 0 &&
 						    !world->GetLocalPlayer()->GetWeapon()->IsReloading() &&
 						    GetSprintState() == 0.0f) {
 							AudioParam params;


### PR DESCRIPTION
'IsReadyToUseTool' checks ammo count, whereas this method does all the same checks. (At least, for a client-sided ToolWeapon.)

Fixes #858.