### PR TITLE
Added a selection menu for the next spawn loadout

### DIFF
--- a/Sources/Client/Client.cpp
+++ b/Sources/Client/Client.cpp
@@ -519,6 +519,18 @@ namespace spades {
 			}
 		}
 
+		void Client::NextSpawnPressed() {
+			WeaponType weap = limbo->GetSelectedWeapon();
+			int team = limbo->GetSelectedTeam();
+			inGameLimbo = false;
+			if (team == 2)
+				team = 255;
+
+			this->hasNextSpawnConfig = true;
+			this->nextTeam = team;
+			this->nextWeapon = weap;
+		}
+
 		void Client::ShowAlert(const std::string &contents, AlertType type) {
 			float timeout;
 			switch (type) {

--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -286,10 +286,15 @@ namespace spades {
 
 			bool inGameLimbo;
 
+			bool hasNextSpawnConfig;
+			int nextTeam;
+			WeaponType nextWeapon;
+
 			float GetLocalFireVibration();
 			void CaptureColor();
 			bool IsLimboViewActive();
 			void SpawnPressed();
+			void NextSpawnPressed();
 
 			Player *HotTrackedPlayer(hitTag_t *hitFlag);
 

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -517,6 +517,16 @@ namespace spades {
 
 			if (player->IsAlive())
 				lastAliveTime = time;
+			else if (hasNextSpawnConfig) {
+				Player *p = world->GetLocalPlayer();
+				if (p->GetTeamId() != nextTeam) {
+					net->SendTeamChange(nextTeam);
+				}
+				if (nextTeam != 2 && p->GetWeapon()->GetWeaponType() != nextWeapon) {
+					net->SendWeaponChange(nextWeapon);
+				}
+				hasNextSpawnConfig = false;
+			}
 
 			if (player->GetHealth() < lastHealth) {
 				// ouch!

--- a/Sources/Client/LimboView.cpp
+++ b/Sources/Client/LimboView.cpp
@@ -75,8 +75,13 @@ namespace spades {
 
 			//! The "Spawn" button that you press when you're ready to "spawn".
 			items.push_back(MenuItem(MenuSpawn,
-			                         AABB2(left + contentsWidth - 266.f, firstY + 4.f, 256.f, 64.f),
+			                         AABB2(left + contentsWidth - 266.f, firstY, 256.f, 48.f),
 			                         _Tr("Client", "Spawn")));
+
+			//! The next spawn button to activate the settings the next time you spawn
+			items.push_back(MenuItem(MenuNextSpawn,
+				                     AABB2(left + contentsWidth - 266.f, firstY + 52.f, 256.f, 48.f),
+					                 _Tr("Client", "Set For Next Spawn")));
 
 			cursorPos = MakeVector2(renderer->ScreenWidth() * .5f, renderer->ScreenHeight() * .5f);
 
@@ -116,6 +121,7 @@ namespace spades {
 							case MenuWeaponSMG: selectedWeapon = SMG_WEAPON; break;
 							case MenuWeaponShotgun: selectedWeapon = SHOTGUN_WEAPON; break;
 							case MenuSpawn: client->SpawnPressed(); break;
+							case MenuNextSpawn: client->NextSpawnPressed(); break;
 						}
 					}
 				}
@@ -156,6 +162,11 @@ namespace spades {
 						if (selectedTeam == 2) {
 							item.visible = false;
 						}
+						break;
+					case MenuNextSpawn:
+						if (client && client->GetWorld() && client->world->GetLocalPlayer() && client->world->GetLocalPlayer()->IsAlive() && client->world->GetLocalPlayer()->GetTeamId() >= 2)
+							item.visible = false;
+						break;
 					default:;
 				}
 

--- a/Sources/Client/LimboView.h
+++ b/Sources/Client/LimboView.h
@@ -38,7 +38,8 @@ namespace spades {
 				MenuWeaponRifle,
 				MenuWeaponSMG,
 				MenuWeaponShotgun,
-				MenuSpawn
+				MenuSpawn,
+				MenuNextSpawn
 			};
 			struct MenuItem {
 				MenuType type;


### PR DESCRIPTION
This adds a new button under "Spawn" in the Limbo menu to set the next spawn's loadout. This allows you to set your next loadout for when you'll die rather than killing yourself if you want another gun and not continuing the battle you're currently in. List of issues with the current implementation:

- Might be excessive to check if player is alive on every LocalPlayer update
- You can see the button when you just joined a game. I disabled it for when you're in spectator mode since you can't die but couldn't figure out how for the initial menu.