### PR TITLE
Disable spurious opengl deprecations warning on mac.

### DIFF
--- a/Sources/Imports/OpenGL.h
+++ b/Sources/Imports/OpenGL.h
@@ -10,6 +10,7 @@
 
 // TODO: support other platform
 #if __APPLE__
+#define GL_SILENCE_DEPRECATION 1
 #include <OpenGL/gl3.h>
 #include <OpenGL/gl3ext.h>
 #else


### PR DESCRIPTION
Metal API had been prioritised thus the deprecation.