### PR TITLE
Fix crash due to shader program linking error

### DIFF
--- a/Resources/Shaders/Shadow/MapRadiosityNull.vs
+++ b/Resources/Shaders/Shadow/MapRadiosityNull.vs
@@ -24,7 +24,7 @@ void PrepareForRadiosity_Map(vec3 vertexCoord, vec3 normal) {
 	hemisphereLighting = 1. - normal.z * .2;
 }
 
-void PrepareForRadiosityForMap_Map(vec3 vertexCoord, vec3 normal) {
+void PrepareForRadiosityForMap_Map(vec3 vertexCoord, vec3 centerCoord, vec3 normal) {
 	hemisphereLighting = 1. - normal.z * .2;
 }
 


### PR DESCRIPTION
When built from master, Openspades would crash at startup with the
following error:
```
Error while linking a program: 'Shaders/BasicBlock.program'

error: unresolved reference to function 'PrepareForRadiosityForMap_Map'
```
The culprit was said function's definition in `MapRadiosityNull.vs`
which was missing a parameter. Fixes #944