### PR TITLE
Player.cpp: Disable recoil if not local player

### DIFF
--- a/Sources/Client/Player.cpp
+++ b/Sources/Client/Player.cpp
@@ -788,10 +788,12 @@ namespace spades {
 
 			horzModifier *= sqrt(1 - pow(o.z, 4));
 
-			o += GetRight() * rec.x * triWave * horzModifier;
-			o += GetUp() * std::min(rec.y, std::max(0.f, upLimit)) * vertModifier;
-			o = o.Normalize();
-			SetOrientation(o);
+			if (this->IsLocalPlayer()) {
+				o += GetRight() * rec.x * triWave * horzModifier;
+				o += GetUp() * std::min(rec.y, std::max(0.f, upLimit)) * vertModifier;
+				o = o.Normalize();
+				SetOrientation(o);
+			}
 
 			reloadingServerSide = false;
 		}


### PR DESCRIPTION
This PR fixes an issue where if user with OpenSpades client is spectating
someone they would see recoil even tho there is none (Player is hacking).

This can get absolutely hard to detect and can make staff think the player
is not cheating while they absolutely are.

This leaves the cheater in game where they can make the game less
fun for others. Which is not what anybody wants.