### PR TITLE
NetClient.cpp: Actually send Enhanced version packet

### DIFF
--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -1539,6 +1539,7 @@ namespace spades {
 				}
 
 				wri.Update(lengthLabel, (uint8_t)(wri.GetPosition() - beginLabel));
+				enet_peer_send(peer, 0, wri.CreatePacket());
 			}
 		}
 


### PR DESCRIPTION
Currently OpenSpades doesn't send the extended version info which contains
some useful info to the server even when being told that it wants it.

This commit adds sending of the packet so servers will receive such info when
they ask for it.

This fixed the following commit where this feature was introduced but never fully
implemented: https://github.com/yvt/openspades/commit/a6bb4ac7e2afee6323b5a0cf7998ae16dd9ce35f


Thanks to DarkNeutrino for the help with commit and title/description