### PR TITLE
Add variation in SMG ejecting brass velocity

### DIFF
--- a/Sources/Client/ClientPlayer.cpp
+++ b/Sources/Client/ClientPlayer.cpp
@@ -1331,7 +1331,11 @@ namespace spades {
 						Vector3 vel;
 						vel = p.GetFront() * 0.5f + p.GetRight() + p.GetUp() * 0.2f;
 						switch (p.GetWeapon().GetWeaponType()) {
-							case SMG_WEAPON: vel -= p.GetFront() * 0.7f; break;
+							case SMG_WEAPON:
+								vel -= p.GetFront() * (0.6f + SampleRandomFloat()/5);
+								vel += p.GetRight() * (SampleRandomFloat()/5 - 0.1f);
+								vel += p.GetUp() * (SampleRandomFloat()/5 - 0.1f);
+								break;
 							case SHOTGUN_WEAPON: vel *= .5f; break;
 							default: break;
 						}


### PR DESCRIPTION
Without this commit, the SMG's ejecting brass tends to fall unnaturally:
If the gun hasn't moved, each casing falls in the exact same trajectory
and in the exact same location.

This commit adds a small amount of random variation to each casing's
veloctiy, which looks more natural.

Tested on Linux, both as a player and in spectator mode.