### PR TITLE
Plumb method for ejecting brass; add ejecting shotgun casings at correct time

### DIFF
--- a/Sources/Client/Client.h
+++ b/Sources/Client/Client.h
@@ -463,6 +463,7 @@ namespace spades {
 			void PlayerJumped(Player &) override;
 			void PlayerLanded(Player &, bool hurt) override;
 			void PlayerFiredWeapon(Player &) override;
+			void PlayerEjectedBrass(Player &) override;
 			void PlayerDryFiredWeapon(Player &) override;
 			void PlayerReloadingWeapon(Player &) override;
 			void PlayerReloadedWeapon(Player &) override;

--- a/Sources/Client/ClientPlayer.h
+++ b/Sources/Client/ClientPlayer.h
@@ -106,6 +106,7 @@ namespace spades {
 
 			bool IsChangingTool();
 			void FiredWeapon();
+			void EjectedBrass();
 			void ReloadingWeapon();
 			void ReloadedWeapon();
 

--- a/Sources/Client/Client_Update.cpp
+++ b/Sources/Client/Client_Update.cpp
@@ -639,6 +639,13 @@ namespace spades {
 
 			clientPlayers.at(p.GetId())->FiredWeapon();
 		}
+
+		void Client::PlayerEjectedBrass(spades::client::Player &p) {
+			SPADES_MARK_FUNCTION();
+
+			clientPlayers.at(p.GetId())->EjectedBrass();
+		}
+
 		void Client::PlayerDryFiredWeapon(spades::client::Player &p) {
 			SPADES_MARK_FUNCTION();
 

--- a/Sources/Client/IWorldListener.h
+++ b/Sources/Client/IWorldListener.h
@@ -48,6 +48,7 @@ namespace spades {
 			virtual void PlayerJumped(Player &) = 0;
 			virtual void PlayerLanded(Player &, bool hurt) = 0;
 			virtual void PlayerFiredWeapon(Player &) = 0;
+			virtual void PlayerEjectedBrass(Player &) = 0;
 			virtual void PlayerDryFiredWeapon(Player &) = 0;
 			virtual void PlayerReloadingWeapon(Player &) = 0;
 			virtual void PlayerReloadedWeapon(Player &) = 0;

--- a/Sources/Client/Weapon.cpp
+++ b/Sources/Client/Weapon.cpp
@@ -35,6 +35,7 @@ namespace spades {
 		      shooting(false),
 		      shootingPreviously(false),
 		      reloading(false),
+		      unejectedBrass(false),
 		      nextShotTime(0.f),
 		      reloadStartTime(-101.f),
 		      reloadEndTime(-100.f),
@@ -57,6 +58,8 @@ namespace spades {
 		}
 
 		void Weapon::SetShooting(bool b) { shooting = b; }
+
+		void Weapon::SetUnejectedBrass(bool b) { unejectedBrass = b; }
 
 		bool Weapon::IsReadyToShoot() {
 			return (ammo > 0 || !owner.IsLocalPlayer()) && time >= nextShotTime &&
@@ -87,6 +90,7 @@ namespace spades {
 				// Automatic operation of weapon.
 				if (time >= nextShotTime && (ammo > 0 || !ownerIsLocalPlayer)) {
 					fired = true;
+					unejectedBrass = true;
 
 					// Consume an ammo.
 					if (ammo > 0) {
@@ -97,6 +101,7 @@ namespace spades {
 						world.GetListener()->PlayerFiredWeapon(owner);
 					}
 					nextShotTime += GetDelay();
+					ejectBrassTime = time + GetEjectBrassTime();
 				} else if (time >= nextShotTime) {
 					dryFire = true;
 				}
@@ -138,6 +143,9 @@ namespace spades {
 							world.GetListener()->PlayerReloadedWeapon(owner);
 					}
 				}
+			} else if (unejectedBrass && time >= ejectBrassTime) {
+				unejectedBrass = false;
+				world.GetListener()->PlayerEjectedBrass(owner);
 			}
 			time += dt;
 
@@ -205,6 +213,7 @@ namespace spades {
 			int GetClipSize() override { return 10; }
 			int GetMaxStock() override { return 50; }
 			float GetReloadTime() override { return 2.5f; }
+			float GetEjectBrassTime() override { return 0.f; }
 			bool IsReloadSlow() override { return false; }
 			WeaponType GetWeaponType() override { return RIFLE_WEAPON; }
 			int GetDamage(HitType type, float distance) override {
@@ -232,6 +241,7 @@ namespace spades {
 			int GetClipSize() override { return 30; }
 			int GetMaxStock() override { return 120; }
 			float GetReloadTime() override { return 2.5f; }
+			float GetEjectBrassTime() override { return 0.f; }
 			bool IsReloadSlow() override { return false; }
 			WeaponType GetWeaponType() override { return SMG_WEAPON; }
 			int GetDamage(HitType type, float distance) override {
@@ -259,6 +269,7 @@ namespace spades {
 			int GetClipSize() override { return 6; }
 			int GetMaxStock() override { return 48; }
 			float GetReloadTime() override { return 0.5f; }
+			float GetEjectBrassTime() override { return 0.6f; }
 			bool IsReloadSlow() override { return true; }
 			WeaponType GetWeaponType() override { return SHOTGUN_WEAPON; }
 			int GetDamage(HitType type, float distance) override {
@@ -289,6 +300,7 @@ namespace spades {
 			int GetClipSize() override { return 8; }
 			int GetMaxStock() override { return 48; }
 			float GetReloadTime() override { return 2.5f; }
+			float GetEjectBrassTime() override { return 0.f; }
 			bool IsReloadSlow() override { return false; }
 			WeaponType GetWeaponType() override { return RIFLE_WEAPON; }
 			int GetDamage(HitType type, float distance) override {
@@ -321,6 +333,7 @@ namespace spades {
 			int GetClipSize() override { return 30; }
 			int GetMaxStock() override { return 150; }
 			float GetReloadTime() override { return 2.5f; }
+			float GetEjectBrassTime() override { return 0.f; }
 			bool IsReloadSlow() override { return false; }
 			WeaponType GetWeaponType() override { return SMG_WEAPON; }
 			int GetDamage(HitType type, float distance) override {
@@ -348,6 +361,7 @@ namespace spades {
 			int GetClipSize() override { return 8; }
 			int GetMaxStock() override { return 48; }
 			float GetReloadTime() override { return 0.4f; }
+			float GetEjectBrassTime() override { return 0.6f; }
 			bool IsReloadSlow() override { return true; }
 			WeaponType GetWeaponType() override { return SHOTGUN_WEAPON; }
 			int GetDamage(HitType type, float distance) override {

--- a/Sources/Client/Weapon.h
+++ b/Sources/Client/Weapon.h
@@ -37,7 +37,9 @@ namespace spades {
 			bool shooting;
 			bool shootingPreviously;
 			bool reloading;
+			bool unejectedBrass;
 			float nextShotTime;
+			float ejectBrassTime;
 			float reloadStartTime;
 			float reloadEndTime;
 
@@ -56,6 +58,7 @@ namespace spades {
 			virtual int GetClipSize() = 0;
 			virtual int GetMaxStock() = 0;
 			virtual float GetReloadTime() = 0;
+			virtual float GetEjectBrassTime() = 0;
 			virtual bool IsReloadSlow() = 0;
 			virtual int GetDamage(HitType, float distance) = 0;
 			virtual WeaponType GetWeaponType() = 0;
@@ -70,6 +73,7 @@ namespace spades {
 			void Restock();
 			void Reset();
 			void SetShooting(bool);
+			void SetUnejectedBrass(bool);
 
 			/** @return true when fired. */
 			bool FrameNext(float);
@@ -82,6 +86,7 @@ namespace spades {
 
 			bool IsShooting() const { return shooting; }
 			bool IsReloading() const { return reloading; }
+			bool IsUnejectedBrass() const { return unejectedBrass; }
 			int GetAmmo() { return ammo; }
 			int GetStock() { return stock; }
 


### PR DESCRIPTION
Break out ejecting brass into a dedicated method. Trigger this method after
every shot. Add in appropriate delay so that shotgun casings are ejected
during the pump action rather than when the shot is fired.

I was a little uncertain what to do around the `ComputeAmbience` and
`SetSoundEnvironment` stuff - if my `EjectedBrass` method needs those
parts, let me know.

Tested on Linux, both as a player and in spectator mode.

Closes #917 , related to #909 