### PR TITLE
Add Nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,17 @@ jobs:
           build-type: RelWithDebInfo
           configure-options: -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_TOOLCHAIN_FILE=${{ runner.workspace }}/openspades/vcpkg/scripts/buildsystems/vcpkg.cmake -D VCPKG_TARGET_TRIPLET=x64-osx -D CMAKE_OSX_ARCHITECTURES=x86_64
           parallel: 8
+  
+  build-nix:
+    name: Build (Linux + Nix)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+
+      - name: Build Nix flake
+        run: nix build
+

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ OpenSpades.msvc/
 # Linux build path
 openspades.mk/
 
+# Nix
+/outputs
+/result
+
 # fltk / fluid output leftovers
 Sources/Gui/DetailConfigWindow.txt
 Sources/Gui/MainWindow.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,8 @@ else()
 	include_directories(${CURL_INCLUDE_DIRS})
 	include_directories(${FREETYPE_INCLUDE_DIRS})
 	include_directories(${OpusFile_INCLUDE_DIR})
+	include_directories(${Opus_INCLUDE_DIR})
+	include_directories(${Ogg_INCLUDE_DIR})
 endif()
 
 add_subdirectory(Resources)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ Alternatively, to install the game to a different directory, take the following 
 
 After successful installation, optionally you can remove the source code and build outputs to save disk space (~100MB).
 
+#### On Linux (from source, by Nix Flakes)
+To build and run OpenSpades from the latest source code:
+
+```bash
+nix shell github:yvt/openspades -c openspades
+```
+
+To build and run OpenSpades for development:
+
+```bash
+git clone https://github.com/yvt/openspades.git && cd openspades
+nix develop
+# note: this will patch CMake files in the source tree
+cmakeBuildType=RelWithDebInfo cmakeConfigurePhase
+buildPhase
+bin/openspades
+```
+
+**note**: Nix Flakes are an experimental feature of Nix and must be enabled manually. See [this wiki article](https://nixos.wiki/wiki/Flakes) for how to do that.
+
 ### On Windows (with Visual Studio)
 1. Get the required software if you haven't already:
   * CMake 2.8+

--- a/Resources/downloadpak.sh
+++ b/Resources/downloadpak.sh
@@ -27,8 +27,13 @@ OUTPUT_DIR="."
 if [ -f "$PAK_NAME" ]; then
 	exit 0
 fi
+# TODO: Check if the extracted files are present and up-to-date (#988)
 
-wget "$PAK_URL" -O "$PAK_NAME"
+if [ -n "$OPENSPADES_DEVPAK_PATH" ]; then
+	cp "$OPENSPADES_DEVPAK_PATH" "$PAK_NAME"
+else
+	wget "$PAK_URL" -O "$PAK_NAME"
+fi
 unzip -o "$PAK_NAME" -d "$OUTPUT_DIR"
 
 # relocate paks to the proper location

--- a/cmake/FindGLEW2.cmake
+++ b/cmake/FindGLEW2.cmake
@@ -36,6 +36,12 @@ ELSE (WIN32)
 		/sw/lib
 		/opt/local/lib
 		DOC "The GLEW library")
+	FIND_PATH( GLU_INCLUDE_DIR GL/glu.h
+		/usr/include
+		/usr/local/include
+		/sw/include
+		/opt/local/include
+		DOC "The directory where GL/glu.h resides")
 ENDIF (WIN32)
 
 IF (GLEW_INCLUDE_DIR)

--- a/cmake/FindOpus.cmake
+++ b/cmake/FindOpus.cmake
@@ -25,6 +25,36 @@ FIND_LIBRARY(OpusFile_LIBRARY
   /opt
 )
 
+FIND_PATH(Opus_INCLUDE_DIR opus/opus_multistream.h
+  HINTS
+  $ENV{OPUSDIR}
+  PATH_SUFFIXES include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/SDL2
+  /usr/include/SDL2
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+
+FIND_PATH(Ogg_INCLUDE_DIR ogg/ogg.h
+  HINTS
+  $ENV{OPUSDIR}
+  PATH_SUFFIXES include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/SDL2
+  /usr/include/SDL2
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+
 set(OpusFile_FOUND "NO")
 if(OpusFile_INCLUDE_DIR AND OpusFile_LIBRARY)
   set(OpusFile_FOUND "YES")

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656633783,
+        "narHash": "sha256-nXMIGtQXBGzO57nkPxgEOx8HLRwVQ+d1WkOnE01JG4A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "95e79164be1f7d883ed9ffda8b7d4ad3a17e6c1e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "A compatible client of Ace of Spades 0.75";
+  
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit (pkgs) stdenv;
+
+          # Non-GPL assets - please see `PakLocation.txt` for the terms of use
+          # and issue #424 for the situation
+          devPackage = pkgs.fetchurl {
+            url = https://github.com/yvt/openspades-paks/releases/download/r33/OpenSpadesDevPackage-r33.zip;
+            sha256 = "CSfcMjoLOroO6NHWjWtUSwD+ZUdA/q1tH6rTeqx3oq0=";
+          };
+          # Google Noto Fonts, licensed under the SIL Open Font License
+          notoFontPak = pkgs.fetchurl {
+            url = https://github.com/yvt/openspades/releases/download/v0.1.1b/NotoFonts.pak;
+            sha256 = "VQYMZNYqNBZ9+01YCcabqqIfck/mU/BRcFZKXpBEX00=";
+          };
+        in rec {
+          packages.default = packages.openspades;
+
+          packages.openspades = stdenv.mkDerivation rec {
+            pname = "openspades";
+            version = "0.1.5-beta";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [ cmake imagemagick unzip zip file ];
+
+            buildInputs = with pkgs; 
+              ([
+                freetype SDL2 SDL2_image libGL zlib curl glew opusfile openal libogg
+              ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+                darwin.apple_sdk.frameworks.Cocoa
+              ]);
+
+            cmakeFlags = [ "-DOPENSPADES_INSTALL_BINARY=bin" ];
+
+            inherit notoFontPak;
+          
+            # Used by `downloadpak.sh`. Instructs the script to copy the
+            # development package from this path instead of downloading it.
+            OPENSPADES_DEVPAK_PATH = devPackage;
+          
+            postPatch = ''
+              patchShebangs Resources
+            '';
+
+            postInstall = ''
+              cp $notoFontPak $out/share/games/openspades/Resources/
+            '';
+
+            NIX_CFLAGS_LINK = "-lopenal";
+          };
+        });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+with import <nixpkgs> {};
+
+with pkgs.xorg;
+
+runCommand "dummy" rec {
+  nativeBuildInputs = [ cmake imagemagick unzip zip file gcc ];
+
+  buildInputs = [
+    freetype SDL2 SDL2_image libGL zlib curl glew opusfile openal libogg pkgconfig libopus libGLU
+    libXext pkg-config
+  ];
+
+  NIX_CFLAGS_LINK = [ "-L${libXext}/lib" ];
+  NIX_CFLAGS_COMPILE= ["-I${libogg.dev}/include" "-I${libopus.dev}/include" "-I${libGLU.dev}/include" ];
+
+  LD_LIBRARY_PATH = [ "${openal}/lib" ];
+} ""

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,8 @@
-with import <nixpkgs> {};
-
-with pkgs.xorg;
-
-runCommand "dummy" rec {
-  nativeBuildInputs = [ cmake imagemagick unzip zip file gcc ];
-
-  buildInputs = [
-    freetype SDL2 SDL2_image libGL zlib curl glew opusfile openal libogg pkgconfig libopus libGLU
-    libXext pkg-config
-  ];
-
-  NIX_CFLAGS_LINK = [ "-L${libXext}/lib" ];
-  NIX_CFLAGS_COMPILE= ["-I${libogg.dev}/include" "-I${libopus.dev}/include" "-I${libGLU.dev}/include" ];
-
-  LD_LIBRARY_PATH = [ "${openal}/lib" ];
-} ""
+# Flake's devShell for non-flake-enabled nix instances
+let
+  compat = builtins.fetchGit {
+    url = "https://github.com/edolstra/flake-compat.git";
+    rev = "b4a34015c698c7793d592d66adbab377907a2be8";
+  };
+in
+  (import compat {src = ./.;}).shellNix.default


### PR DESCRIPTION
This PR adds a [Nix flake](https://nixos.wiki/wiki/Flakes) that can be used in two ways:
1. The users can build and install the game from source code with minimal efforts. E.g., you can launch the game from this branch by `nix shell github:yvt/openspades/patch/nix -c openspades`
2. The developers can start a development shell by `nix develop`.

This PR also adds `shell.nix`, which contains a compatibility wrapper for non-flake Nix instances.