### PR TITLE
Don't try looking up OpenAL drivers if there's no OpenAL library

### DIFF
--- a/Sources/Gui/StartupScreenHelper.cpp
+++ b/Sources/Gui/StartupScreenHelper.cpp
@@ -164,13 +164,13 @@ namespace spades {
 						  return std::string();
 					  }
 				  }));
-			}
-
-			// check openAL drivers
-			SPLog("Checking OpenAL available drivers");
-			openalDevices = audio::ALDevice::DeviceList();
-			for (const auto &d: openalDevices) {
-				SPLog("%s", d.c_str());
+			} else {
+				// check openAL drivers
+				SPLog("Checking OpenAL available drivers");
+				openalDevices = audio::ALDevice::DeviceList();
+				for (const auto &d: openalDevices) {
+					SPLog("%s", d.c_str());
+				}
 			}
 
 			// check GL capabilities


### PR DESCRIPTION
Fixes segmentation fault for those who don't have OpenAL installed.

```
2023/04/22 20:51:15 [ALFuncs.cpp:249] Linking with OpenAL library.
2023/04/22 20:51:15 [StartupScreenHelper.cpp:170] Checking OpenAL available drivers

Thread 1 "openspades" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
```