### PR TITLE
ci: fix macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-macos:
     name: Build (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
macos-10 is deprecated and does not work anymore.

See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners for available runners.