### PR TITLE
chore(ci): update cache and install-nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           path: openspades
 
       - name: Cache vcpkg and dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             vcpkg/installed
@@ -47,7 +47,7 @@ jobs:
           path: openspades
 
       - name: Cache vcpkg and dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             vcpkg/installed
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
+        uses: cachix/install-nix-action@v18
 
       - name: Build Nix flake
         run: nix build


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

[CMake Build](https://github.com/ashutoshvarma/action-cmake-build) is no longer being updated so I made Actions directly invoke CMake from shell