### PR TITLE
README: update nixos link to official wiki url

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ buildPhase
 bin/openspades
 ```
 
-**note**: Nix Flakes are an experimental feature of Nix and must be enabled manually. See [this wiki article](https://nixos.wiki/wiki/Flakes) for how to do that.
+**note**: Nix Flakes are an experimental feature of Nix and must be enabled manually. See [this wiki article](https://wiki.nixos.org/wiki/Flakes) for how to do that.
 
 ### On Windows (with Visual Studio)
 1. Get the required software if you haven't already:


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org/

ref: NixOS/foundation#113