### PR TITLE
fix(core): add missing `string.h` includes

### DIFF
--- a/Sources/Core/ConcurrentDispatch.cpp
+++ b/Sources/Core/ConcurrentDispatch.cpp
@@ -39,6 +39,8 @@
 #endif
 #endif
 
+#include <string.h>
+
 #include "ConcurrentDispatch.h"
 #include "Debug.h"
 #include "Exception.h"

--- a/Sources/Core/DynamicLibrary.cpp
+++ b/Sources/Core/DynamicLibrary.cpp
@@ -85,6 +85,7 @@ namespace spades {
 #include "DynamicLibrary.h"
 #include "Exception.h"
 #include <dlfcn.h>
+#include <string.h>
 
 namespace spades {
 	DynamicLibrary::DynamicLibrary(const char *fn) {


### PR DESCRIPTION
`string.h` is needed for `strchr()` and `memset()`. Failure to include it prevents compilation on certain platforms such as gcc 14.2 + glibc 2.40.