### PR TITLE
Add persistent block color feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ UserInterfaceState.xcuserstate
 *.sublime-workspace
 *.sublime-project
 
+# Vscode
+.vscode/
+
 # Windows related
 Thumbs.db
 

--- a/Sources/Client/NetClient.cpp
+++ b/Sources/Client/NetClient.cpp
@@ -46,6 +46,7 @@
 #include <Core/TMPUtils.h>
 
 DEFINE_SPADES_SETTING(cg_unicode, "1");
+DEFINE_SPADES_SETTING(cg_persistentBlockColor, "1");
 
 namespace spades {
 	namespace client {
@@ -1017,10 +1018,15 @@ namespace spades {
 						default: SPRaise("Received invalid weapon: %d", weapon);
 					}
 
-					auto p =
-					  stmp::make_unique<Player>(*GetWorld(), pId, wType, team, savedPlayerPos[pId],
+					auto p = stmp::make_unique<Player>(*GetWorld(), pId, wType, team, savedPlayerPos[pId],
 					                            GetWorld()->GetTeam(team).color);
 					p->SetPosition(pos);
+					// Don't reset my block color when I respawn
+					if(cg_persistentBlockColor && GetLocalPlayerOrNull() && pId == GetWorld()->GetLocalPlayerIndex()) {
+						p->SetHeldBlockColor(GetWorld()->GetLocalPlayer()->GetBlockColor());
+						SendHeldBlockColor();
+					}
+
 					GetWorld()->SetPlayer(pId, std::move(p));
 
 					Player &pRef = GetWorld()->GetPlayer(pId).value();


### PR DESCRIPTION
If enabled, it will keep your selected block color the same when you respawn instead of resetting it to gray